### PR TITLE
add record-support: dot-accessing and spreading

### DIFF
--- a/interp/record_test.go
+++ b/interp/record_test.go
@@ -55,3 +55,137 @@ func TestRecordLiteralEvalTrailingComma(t *testing.T) {
 		t.Fatalf("expected 2 fields, got %d", len(r.Fields))
 	}
 }
+func TestRecordFieldAccess(t *testing.T) {
+	s := NewState()
+	text := "r = { name = 'value', key = 8 }\nreturn r.name"
+	if err := s.Eval([]rune(text)); err != nil {
+		t.Fatal(err)
+	}
+	v := s.RetVals.Pop()
+	vs, ok := v.(VString)
+	if !ok {
+		t.Fatalf("expected VString, got %T", v)
+	}
+	if vs != VString("value") {
+		t.Fatalf("expected 'value', got %s", vs)
+	}
+}
+
+func TestRecordFieldAccessNumber(t *testing.T) {
+	s := NewState()
+	text := "r = { name = 'value', key = 8 }\nreturn r.key"
+	if err := s.Eval([]rune(text)); err != nil {
+		t.Fatal(err)
+	}
+	v := s.RetVals.Pop()
+	vn, ok := v.(VNumber)
+	if !ok {
+		t.Fatalf("expected VNumber, got %T", v)
+	}
+	if vn != VNumber(8) {
+		t.Fatalf("expected 8, got %v", vn)
+	}
+}
+
+func TestRecordSpread(t *testing.T) {
+	s := NewState()
+	text := "r1 = { a = 1, b = 2 }\nr2 = { ...r1, c = 3 }\nreturn r2"
+	if err := s.Eval([]rune(text)); err != nil {
+		t.Fatal(err)
+	}
+	v := s.RetVals.Pop()
+	r, ok := v.(*VRecord)
+	if !ok {
+		t.Fatalf("expected *VRecord, got %T", v)
+	}
+	if len(r.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(r.Fields))
+	}
+	
+	// Check that spread fields are present
+	if val, ok := r.Fields["a"]; !ok {
+		t.Fatalf("missing field 'a' from spread")
+	} else if vn, ok := val.(VNumber); !ok || vn != VNumber(1) {
+		t.Fatalf("expected field 'a' to be 1, got %v", val)
+	}
+	
+	if val, ok := r.Fields["b"]; !ok {
+		t.Fatalf("missing field 'b' from spread")
+	} else if vn, ok := val.(VNumber); !ok || vn != VNumber(2) {
+		t.Fatalf("expected field 'b' to be 2, got %v", val)
+	}
+	
+	// Check new field
+	if val, ok := r.Fields["c"]; !ok {
+		t.Fatalf("missing field 'c'")
+	} else if vn, ok := val.(VNumber); !ok || vn != VNumber(3) {
+		t.Fatalf("expected field 'c' to be 3, got %v", val)
+	}
+}
+
+func TestRecordSpreadOverride(t *testing.T) {
+	s := NewState()
+	text := "r1 = { a = 1, b = 2 }\nr2 = { ...r1, b = 20 }\nreturn r2.b"
+	if err := s.Eval([]rune(text)); err != nil {
+		t.Fatal(err)
+	}
+	v := s.RetVals.Pop()
+	vn, ok := v.(VNumber)
+	if !ok {
+		t.Fatalf("expected VNumber, got %T", v)
+	}
+	if vn != VNumber(20) {
+		t.Fatalf("expected 20 (overridden value), got %v", vn)
+	}
+}
+
+func TestRecordMultipleSpreads(t *testing.T) {
+	s := NewState()
+	text := "r1 = { a = 1 }\nr2 = { b = 2 }\nr3 = { ...r1, ...r2, c = 3 }\nreturn r3"
+	if err := s.Eval([]rune(text)); err != nil {
+		t.Fatal(err)
+	}
+	v := s.RetVals.Pop()
+	r, ok := v.(*VRecord)
+	if !ok {
+		t.Fatalf("expected *VRecord, got %T", v)
+	}
+	if len(r.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(r.Fields))
+	}
+	
+	// Check all fields are present
+	expectedFields := map[string]float64{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+	for fieldName, expectedValue := range expectedFields {
+		if val, ok := r.Fields[fieldName]; !ok {
+			t.Fatalf("missing field '%s'", fieldName)
+		} else if vn, ok := val.(VNumber); !ok || vn != VNumber(expectedValue) {
+			t.Fatalf("expected field '%s' to be %v, got %v", fieldName, expectedValue, val)
+		}
+	}
+}
+
+func TestNestedRecordsWithChainedFieldAccess(t *testing.T) {
+	s := NewState()
+	text := `admins = { alice = { name = 'Alice', age = 30 } }
+fun get_alice(r)
+  return r.alice
+end
+alice_name = get_alice(admins).name
+return alice_name`
+	if err := s.Eval([]rune(text)); err != nil {
+		t.Fatal(err)
+	}
+	v := s.RetVals.Pop()
+	vs, ok := v.(VString)
+	if !ok {
+		t.Fatalf("expected VString, got %T", v)
+	}
+	if vs != VString("Alice") {
+		t.Fatalf("expected 'Alice', got %s", vs)
+	}
+}

--- a/parser/record_test.go
+++ b/parser/record_test.go
@@ -22,13 +22,29 @@ func TestParseRecordLiteral(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected RecordLiteralExpr, got %T", exprStmt.Expr)
 	}
-	if len(rec.Fields) != 2 {
-		t.Fatalf("expected 2 fields, got %d", len(rec.Fields))
+	if len(rec.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(rec.Elements))
 	}
-	if _, ok := rec.Fields["name"]; !ok {
+	
+	// Check that both elements are RecordFields
+	for i, elem := range rec.Elements {
+		_, ok := elem.(*ast.RecordField)
+		if !ok {
+			t.Fatalf("expected RecordField at index %d, got %T", i, elem)
+		}
+	}
+	
+	// Check field names
+	fieldMap := make(map[string]bool)
+	for _, elem := range rec.Elements {
+		if field, ok := elem.(*ast.RecordField); ok {
+			fieldMap[field.Key] = true
+		}
+	}
+	if _, ok := fieldMap["name"]; !ok {
 		t.Fatalf("missing field 'name'")
 	}
-	if _, ok := rec.Fields["key"]; !ok {
+	if _, ok := fieldMap["key"]; !ok {
 		t.Fatalf("missing field 'key'")
 	}
 }
@@ -50,10 +66,14 @@ func TestParseRecordLiteralTrailingComma(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected RecordLiteralExpr, got %T", exprStmt.Expr)
 	}
-	if len(rec.Fields) != 1 {
-		t.Fatalf("expected 1 field, got %d", len(rec.Fields))
+	if len(rec.Elements) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(rec.Elements))
 	}
-	if _, ok := rec.Fields["name"]; !ok {
-		t.Fatalf("missing field 'name'")
+	field, ok := rec.Elements[0].(*ast.RecordField)
+	if !ok {
+		t.Fatalf("expected RecordField, got %T", rec.Elements[0])
+	}
+	if field.Key != "name" {
+		t.Fatalf("expected field 'name', got '%s'", field.Key)
 	}
 }

--- a/testdata/test_nested_records.vv
+++ b/testdata/test_nested_records.vv
@@ -1,0 +1,8 @@
+admins = { alice = { name = 'Alice', age = 30 } }
+
+fun get_alice(r)
+  return r.alice
+end
+
+alice_name = get_alice(admins).name
+return alice_name

--- a/testdata/test_record_features.vv
+++ b/testdata/test_record_features.vv
@@ -1,0 +1,6 @@
+person = { name = 'Alice', age = 30 }
+name = person.name
+defaults = { x = 0, y = 0 }
+point = { ...defaults, x = 10 }
+result = point.x
+return result


### PR DESCRIPTION
## Overview
Add two major features for working with records in vvlang:
1. **Dot-accessing**: Access record fields using dot notation (e.g., `r.key`)
2. **Spreading**: Merge records using spread syntax (e.g., `{ ...other_record, key = value }`)

## Features

### Dot-accessing Records
Users can now access record fields using intuitive dot notation:

```vvlang
person = { name = 'Alice', age = 30 }
name = person.name        # 'Alice'
age = person.age          # 30
```

Chained field access is also supported:

```vvlang
company = { ceo = { name = 'Bob', title = 'CEO' } }
ceo_name = company.ceo.name  # 'Bob'
```

### Record Spreading
Merge records and override fields using spread syntax:

```vvlang
defaults = { x = 0, y = 0, z = 0 }
point = { ...defaults, x = 10, y = 20 }  # { x = 10, y = 20, z = 0 }
```

Multiple spreads are supported:

```vvlang
r1 = { a = 1 }
r2 = { b = 2 }
r3 = { ...r1, ...r2, c = 3 }  # { a = 1, b = 2, c = 3 }
```

### Practical Example
```vvlang
admins = {
  alice = { name = 'Alice', age = 30 }
}

fun get_alice(r)
  return r.alice
end

alice_name = get_alice(admins).name  # 'Alice'
```

## Changes

### AST (expr.go)
- Added `FieldAccessExpr` struct for field access expressions
- Refactored `RecordLiteralExpr` to use ordered `Elements` slice
- Added `RecordElement` interface with implementations:
  - `RecordField`: for regular key-value pairs
  - `RecordSpread`: for spread expressions

### Parser (parser.go)
- Modified `parseFieldAccessExpr`: new dedicated parser for dot notation
- Updated `parseRecordLiteralExpr`: support both fields and spreads in order
- Added `TDot` to precedence map with `PCall` precedence for left-associativity
- Changed TDot infix parser from generic `parseInfixExpr` to `parseFieldAccessExpr`

### Interpreter (state.go)
- Added `evalRecordLiteralExpr`: handles ordered element processing for fields and spreads
- Added `evalFieldAccessExpr`: evaluates field access on records
- Updated error messages for spread operations

### Tests
- `TestRecordFieldAccess`: basic field access
- `TestRecordFieldAccessNumber`: field access with different types
- `TestRecordSpread`: basic spread functionality
- `TestRecordSpreadOverride`: field override after spread
- `TestRecordMultipleSpreads`: multiple spreads in one record
- `TestNestedRecordsWithChainedFieldAccess`: nested records with function calls and chaining

