### PR TITLE
add 'let' to separate variable definition and its modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ fun add(a, b)
 end
 
 // define variable
-x = 0
+let x = 0
 
 // here, another simple function
 fun incr_x()
@@ -51,20 +51,20 @@ fun is_space(c)
 end
 
 fun trim_start(text)
-  pos = 0
+  let pos = 0
   while pos < len(text) and is_space(text[pos]) do
     pos = pos + 1
   end
-  return slice(text, pos, len(text))
+  return text[pos:]
 end
 
 fun split(text, sep)
-  lines = []
-  pos = 0
-  start = 0
+  let lines = []
+  let pos = 0
+  let start = 0
   while pos < len(text) do
-    if slice(text, pos, pos+len(sep)) == sep do
-      push(lines, slice(text, start, pos))
+    if text[pos:pos+len(sep)] == sep do
+      push(lines, text[start:pos])
       pos = pos + len(sep)
       start = pos
     else
@@ -75,8 +75,8 @@ fun split(text, sep)
 end
 
 fun parse_line(line)
-  cols = []
-  cells = split(line, ',')
+  let cols = []
+  let cells = split(line, ',')
   while 0 < len(cells) do
     push(cols, trim_start(shift(cells)))
   end
@@ -84,8 +84,8 @@ fun parse_line(line)
 end
 
 fun parse_csv(text)
-  rows = []
-  lines = split(text, '\n')
+  let rows = []
+  let lines = split(text, '\n')
   while 0 < len(lines) do
     push(rows, parse_line(shift(lines)))
   end
@@ -94,13 +94,13 @@ end
 
 fun print_csv(rows)
   while 0 < len(rows) do
-    cols = shift(rows)
+    let cols = shift(rows)
     print(join(cols, "\n"))
   end
 end
 
-text = read_file("test.csv")
-values = parse_csv(text)
+let text = read_file("test.csv")
+let values = parse_csv(text)
 print_csv(values)
 ```
 
@@ -146,17 +146,17 @@ end
 ```
 
 ```
-sprite = import("sprite")
+let sprite = import("sprite")
 
-player = sprite.new('player', 0, 0, 50, 100 'left')
-bullets = []
+let player = sprite.new('player', 0, 0, 50, 100 'left')
+let bullets = []
 
 fun fire()
   push(bullets, sprite.new('bullet', player.x, player.y, 20, 5 player.face))
 end
 
 fun update_bullet(i)
-  bullet = bullets[i]
+  let bullet = bullets[i]
   if bullet.face == 'left' do
     sprite.move_by(bullet, -1, 0)
   else
@@ -168,7 +168,7 @@ fun update_bullet(i)
   end
 end
 
-holding = false
+let holding = false
 
 fun update()
   if get_key('left') do
@@ -187,7 +187,7 @@ fun update()
     holding = false
   end
   
-  i = 0
+  let i = 0
   while i < len(bullets) do
     update_bullet(i)
     i = i + 1
@@ -199,7 +199,7 @@ fun draw()
   
   sprite.draw(player)
   
-  i = 0
+  let i = 0
   while i < len(bullets) do
     sprite.draw(bullets[i])
     i = i + 1
@@ -228,7 +228,11 @@ end
 ### Variables
 
 ```vv
-variable_x = true
+## definition
+let variable_x = true
+
+## update
+variable_x = false
 ```
 
 Variables are mutable and dynamically typed.
@@ -266,7 +270,7 @@ end
 ### While
 
 ```vv
-i = 0
+let i = 0
 while i < 10
   i = i + 1
 end

--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -63,6 +63,15 @@ func (stmt *IfStmt) Inspect() string {
 	return fmt.Sprintf("IfStmt{%s, %s, %s}", stmt.Cond.Inspect(), strings.Join(thenBody, ", "), strings.Join(elseBody, ", "))
 }
 
+type VarAssignStmt struct {
+	Name string
+	Body Expr
+}
+
+func (stmt *VarAssignStmt) Inspect() string {
+	return fmt.Sprintf("VarAssignStmt{\"%s\", %s}", stmt.Name, stmt.Body.Inspect())
+}
+
 type VarDeclStmt struct {
 	Name string
 	Body Expr

--- a/interp/env.go
+++ b/interp/env.go
@@ -30,6 +30,10 @@ func (env *Env) Get(name string) (Value, error) {
 }
 
 func (env *Env) Set(name string, value Value) {
+	env.Values[name] = value
+}
+
+func (env *Env) SetOuter(name string, value Value) {
 	for e := env.outer; e != nil; e = e.outer {
 		if _, ok := e.Values[name]; ok {
 			e.Values[name] = value

--- a/interp/state.go
+++ b/interp/state.go
@@ -84,6 +84,8 @@ func (s *State) evalStmt(stmt ast.Stmt) error {
 		return s.evalReturnStmt(v)
 	case *ast.VarDeclStmt:
 		return s.evalVarDeclStmt(v)
+	case *ast.VarAssignStmt:
+		return s.evalVarAssignStmt(v)
 	case *ast.IfStmt:
 		return s.evalIfStmt(v)
 	case *ast.BreakStmt:
@@ -142,6 +144,15 @@ func (s *State) evalVarDeclStmt(stmt *ast.VarDeclStmt) error {
 		return err
 	}
 	s.Env.Set(stmt.Name, v)
+	return nil
+}
+
+func (s *State) evalVarAssignStmt(stmt *ast.VarAssignStmt) error {
+	v, err := s.evalExpr(stmt.Body)
+	if err != nil {
+		return err
+	}
+	s.Env.SetOuter(stmt.Name, v)
 	return nil
 }
 

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -30,6 +30,7 @@ const (
 	TOr
 	TBreak
 	TContinue
+	TLet
 
 	// symbols
 	TLessEq
@@ -92,6 +93,8 @@ func (ty TokenType) String() string {
 		return "And"
 	case TOr:
 		return "Or"
+	case TLet:
+		return "Let"
 
 	// symbols
 	case TLessEq:
@@ -192,6 +195,7 @@ var Keywords = map[string]TokenType{
 	"or":       TOr,
 	"break":    TBreak,
 	"continue": TContinue,
+	"let":	    TLet,
 }
 
 var Comments = map[string]string{

--- a/parser/assignment_test.go
+++ b/parser/assignment_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestParseVarDecl(t *testing.T) {
-	text := "x = 1"
+	text := "let x = 1"
 	program, err := Parse([]rune(text))
 	if err != nil {
 		t.Fatal(err)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -166,6 +166,10 @@ func (p *Parser) parseStmt() (ast.Stmt, error) {
 
 	if p.curToken.Type == lexer.TIdent && p.peekToken.Type == lexer.TAssign {
 		// `x = expr` form
+		return p.parseVarAssignStmt()
+	}
+
+	if p.curToken.Type == lexer.TLet {
 		return p.parseVarDeclStmt()
 	}
 
@@ -269,12 +273,32 @@ func (p *Parser) parseReturnStmt() (*ast.ReturnStmt, error) {
 }
 
 func (p *Parser) parseVarDeclStmt() (*ast.VarDeclStmt, error) {
+	if err := p.expect(lexer.TLet); err != nil {
+		return nil, err
+	}
+	name := p.curToken.Text
+	if err := p.expect(lexer.TIdent); err != nil {
+		return nil, err
+	}
+	if err := p.expect(lexer.TAssign); err != nil {
+		return nil, err
+	}
+	body, err := p.parseExpr(PLowest)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.VarDeclStmt{
+		Name: name,
+		Body: body,
+	}, nil
+}
+
+func (p *Parser) parseVarAssignStmt() (*ast.VarAssignStmt, error) {
 	name := p.curToken.Text
 
 	if err := p.expectNext(lexer.TAssign); err != nil {
 		return nil, err
 	}
-
 	if err := p.readToken(); err != nil {
 		return nil, err
 	}
@@ -284,7 +308,7 @@ func (p *Parser) parseVarDeclStmt() (*ast.VarDeclStmt, error) {
 		return nil, err
 	}
 
-	return &ast.VarDeclStmt{
+	return &ast.VarAssignStmt{
 		Name: name,
 		Body: expr,
 	}, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestParser(t *testing.T) {
-	text := "fun add(a, b) while true if get_key() == 'enter' return a + b else x = 0.8 return x end end end x = 1 y = add(x, 0.5)"
+	text := "fun add(a, b) while true if get_key() == 'enter' return a + b else let x = 0.8 return x end end end let x = 1 let y = add(x, 0.5)"
 	program, err := Parse([]rune(text))
 	if err != nil {
 		t.Fatal(err)
@@ -22,7 +22,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	text := "fun add(a, b) return a + b end x = 1 y = add(x, 0.5)"
+	text := "fun add(a, b) return a + b end let x = 1 let y = add(x, 0.5)"
 	v, err := Parse([]rune(text))
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +36,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestParseWhile(t *testing.T) {
-	text := "while 1 < 2 x = 1 end"
+	text := "while 1 < 2 let x = 1 end"
 	v, err := Parse([]rune(text))
 	if err != nil {
 		t.Fatal(err)

--- a/testdata/test_list_features.vv
+++ b/testdata/test_list_features.vv
@@ -1,7 +1,7 @@
 // List Support Features Test
 
 // Index access
-xs = [10, 20, 30, 40, 50]
+let xs = [10, 20, 30, 40, 50]
 print(xs[0])   // 10
 print(xs[2])   // 30
 print(xs[-1])  // 50 (negative indexing)
@@ -14,17 +14,17 @@ print(xs[:3])     // [10, 20, 30] (omit start)
 print(xs[:])      // [10, 20, 30, 40, 50] (full slice)
 
 // Spreading
-ys = [1, 2, 3]
-zs = [0, ...ys, 4]
+let ys = [1, 2, 3]
+let zs = [0, ...ys, 4]
 print(zs)  // [0, 1, 2, 3, 4]
 
-as = [100, 200]
-bs = [300, 400]
-cs = [...as, ...bs]
+let as = [100, 200]
+let bs = [300, 400]
+let cs = [...as, ...bs]
 print(cs)  // [100, 200, 300, 400]
 
 // String indexing and slicing
-text = 'hello'
+let text = 'hello'
 print(text[0])    // "h"
 print(text[1:4])  // "ell"
 print(text[:2])   // "he"

--- a/testdata/test_nested_records.vv
+++ b/testdata/test_nested_records.vv
@@ -1,8 +1,8 @@
-admins = { alice = { name = 'Alice', age = 30 } }
+let admins = { alice = { name = 'Alice', age = 30 } }
 
 fun get_alice(r)
   return r.alice
 end
 
-alice_name = get_alice(admins).name
+let alice_name = get_alice(admins).name
 return alice_name

--- a/testdata/test_record_features.vv
+++ b/testdata/test_record_features.vv
@@ -1,6 +1,6 @@
-person = { name = 'Alice', age = 30 }
-name = person.name
-defaults = { x = 0, y = 0 }
-point = { ...defaults, x = 10 }
-result = point.x
+let person = { name = 'Alice', age = 30 }
+let name = person.name
+let defaults = { x = 0, y = 0 }
+let point = { ...defaults, x = 10 }
+let result = point.x
 return result

--- a/testdata/test_simple.vv
+++ b/testdata/test_simple.vv
@@ -1,4 +1,4 @@
-str = 'hello'
+let str = 'hello'
 print(str[0])
 print(str[1:4])
 print(str[:2])


### PR DESCRIPTION
## Motivation

Separate variable difinition from its modification and express it at the syntax level.
Shadowing of variable names are useful, but it should be explicit.

```
// before
x = 0
y = 0
fun incr()
  x = x + 1
  y = 1    // overwrite global y
end

incr()

print(x)  // 1
print(y)  // 1
```

```
// after
let x = 0
let y = 0
fun incr()
  x = x + 1
  let y = 1    // shadowing: just define local variable
end

incr()

print(x)  // 1
print(y)  // 0
```
