### PR TITLE
feat: implement record destructuring and punning

### DIFF
--- a/ast/expr.go
+++ b/ast/expr.go
@@ -153,6 +153,7 @@ func (expr *ListLiteralExpr) Inspect() string {
 	}
 	return fmt.Sprintf("ListLiteralExpr{[%s]}", strings.Join(elements, ", "))
 }
+
 type IndexExpr struct {
 	Position
 	Left  Expr
@@ -190,4 +191,12 @@ type FieldAccessExpr struct {
 
 func (expr *FieldAccessExpr) Inspect() string {
 	return fmt.Sprintf("FieldAccessExpr{%s.%s}", expr.Record.Inspect(), expr.Field)
+}
+
+type NullLiteralExpr struct {
+	Position
+}
+
+func (expr *NullLiteralExpr) Inspect() string {
+	return "NullLiteralExpr{}"
 }

--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -81,6 +81,27 @@ func (stmt *VarDeclStmt) Inspect() string {
 	return fmt.Sprintf("VarDeclStmt{\"%s\", %s}", stmt.Name, stmt.Body.Inspect())
 }
 
+type AssignStmt struct {
+	Name string
+	Body Expr
+}
+
+func (stmt *AssignStmt) Inspect() string {
+	return fmt.Sprintf("AssignStmt{\"%s\", %s}", stmt.Name, stmt.Body.Inspect())
+}
+
+type BlockStmt struct {
+	Body []Stmt
+}
+
+func (stmt *BlockStmt) Inspect() string {
+	var body []string
+	for _, s := range stmt.Body {
+		body = append(body, s.Inspect())
+	}
+	return fmt.Sprintf("BlockStmt{[%s]}", strings.Join(body, ", "))
+}
+
 type ExprStmt struct {
 	Expr
 }

--- a/interp/destruct_test.go
+++ b/interp/destruct_test.go
@@ -1,0 +1,103 @@
+package interp
+
+import "testing"
+
+func TestRecordDestructuring(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]Value
+	}{
+		{
+			name:  "simple destructuring",
+			input: "let { a, b } = { a = 1, b = 2 }\nreturn { x = a, y = b }",
+			expected: map[string]Value{
+				"x": VNumber(1),
+				"y": VNumber(2),
+			},
+		},
+		{
+			name:  "destructuring with alias",
+			input: "let { a as x, b as y } = { a = 1, b = 2 }\nreturn { r1 = x, r2 = y }",
+			expected: map[string]Value{
+				"r1": VNumber(1),
+				"r2": VNumber(2),
+			},
+		},
+		{
+			name:  "mixed punning and alias",
+			input: "let { a, b as y } = { a = 1, b = 2 }\nreturn { r1 = a, r2 = y }",
+			expected: map[string]Value{
+				"r1": VNumber(1),
+				"r2": VNumber(2),
+			},
+		},
+		{
+			name: "destructuring from function return",
+			input: `
+fun some_func()
+  return { value = 100, error = null }
+end
+let { value, error } = some_func()
+return { v = value, e = error }
+`,
+			expected: map[string]Value{
+				"v": VNumber(100),
+				"e": VNull{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewState()
+			if err := s.Eval([]rune(tt.input)); err != nil {
+				t.Fatal(err)
+			}
+			v := s.RetVals.Pop()
+			r, ok := v.(*VRecord)
+			if !ok {
+				t.Fatalf("expected *VRecord, got %T", v)
+			}
+			for k, expectedVal := range tt.expected {
+				actualVal, ok := r.Fields[k]
+				if !ok {
+					t.Fatalf("missing field '%s'", k)
+				}
+				eq, err := actualVal.Equal(expectedVal)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !eq {
+					t.Errorf("field '%s': expected %v, got %v", k, expectedVal, actualVal)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordDestructuringError(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "missing field",
+			input: "let { a, c } = { a = 1, b = 2 }",
+		},
+		{
+			name:  "not a record",
+			input: "let { a } = 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewState()
+			err := s.Eval([]rune(tt.input))
+			if err == nil {
+				t.Fatal("expected error but got nil")
+			}
+		})
+	}
+}

--- a/interp/state.go
+++ b/interp/state.go
@@ -111,6 +111,10 @@ func (s *State) evalStmt(stmt ast.Stmt) error {
 		return s.evalReturnStmt(v)
 	case *ast.VarDeclStmt:
 		return s.evalVarDeclStmt(v)
+	case *ast.AssignStmt:
+		return s.evalAssignStmt(v)
+	case *ast.BlockStmt:
+		return s.evalBlockStmt(v)
 	case *ast.VarAssignStmt:
 		return s.evalVarAssignStmt(v)
 	case *ast.IfStmt:
@@ -178,6 +182,22 @@ func (s *State) evalVarDeclStmt(stmt *ast.VarDeclStmt) error {
 	return nil
 }
 
+func (s *State) evalAssignStmt(stmt *ast.AssignStmt) error {
+	v, err := s.evalExpr(stmt.Body)
+	if err != nil {
+		return err
+	}
+	s.Env.SetOuter(stmt.Name, v)
+	return nil
+}
+
+func (s *State) evalBlockStmt(stmt *ast.BlockStmt) error {
+	s.pushEnv()
+	defer s.popEnv()
+
+	return s.evalBody(stmt.Body)
+}
+
 func (s *State) evalVarAssignStmt(stmt *ast.VarAssignStmt) error {
 	v, err := s.evalExpr(stmt.Body)
 	if err != nil {
@@ -197,6 +217,8 @@ func (s *State) evalExpr(expr ast.Expr) (Value, error) {
 		return VString(v.Value), nil
 	case *ast.RecordLiteralExpr:
 		return s.evalRecordLiteralExpr(v)
+	case *ast.NullLiteralExpr:
+		return VNull{}, nil
 	case *ast.FunLiteralExpr:
 		return s.evalFunLiteralExpr(v)
 	case *ast.FunCallExpr:

--- a/interp/value.go
+++ b/interp/value.go
@@ -18,6 +18,7 @@ const (
 	VTBuiltinFun
 	VTList
 	VTRecord
+	VTNull
 )
 
 func (ty ValueType) String() string {
@@ -36,6 +37,8 @@ func (ty ValueType) String() string {
 		return "list"
 	case VTRecord:
 		return "record"
+	case VTNull:
+		return "null"
 	}
 	return "unknown"
 }
@@ -247,4 +250,23 @@ func (v *VRecord) Equal(other Value) (bool, error) {
 
 func (v *VRecord) LessThan(other Value) (bool, error) {
 	return false, fmt.Errorf("unable to compare records")
+}
+
+type VNull struct{}
+
+func (v VNull) Type() ValueType {
+	return VTNull
+}
+
+func (v VNull) String() string {
+	return "null"
+}
+
+func (v VNull) Equal(other Value) (bool, error) {
+	_, ok := other.(VNull)
+	return ok, nil
+}
+
+func (v VNull) LessThan(other Value) (bool, error) {
+	return false, fmt.Errorf("unable to compare null")
 }

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -35,6 +35,8 @@ const (
 	TLet
 	TTest
 	TAssert
+	TAs
+	TNull
 
 	// symbols
 	TLessEq
@@ -107,7 +109,11 @@ func (ty TokenType) String() string {
 	case TTest:
 		return "Test"
 	case TAssert:
-		return "Assert"	
+		return "Assert"
+	case TAs:
+		return "As"
+	case TNull:
+		return "Null"
 
 	// symbols
 	case TLessEq:
@@ -211,9 +217,11 @@ var Keywords = map[string]TokenType{
 	"or":       TOr,
 	"break":    TBreak,
 	"continue": TContinue,
-	"let":	    TLet,
+	"let":      TLet,
 	"test":     TTest,
 	"assert":   TAssert,
+	"as":       TAs,
+	"null":     TNull,
 }
 
 var Comments = map[string]string{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -87,19 +87,20 @@ func (p *Parser) registerPrefixParsers() {
 		lexer.TFun:      p.parseFunLiteralExpr,
 		lexer.TLBrace:   p.parseListLiteralExpr,
 		lexer.TLBracket: p.parseRecordLiteralExpr,
+		lexer.TNull:     p.parseNullLiteralExpr,
 	}
 }
 
 func (p *Parser) registerInfixParsers() {
 	p.infixParsers = map[lexer.TokenType]InfixParser{
-		lexer.TDot:     p.parseFieldAccessExpr,
-		lexer.THyphen:  p.parseInfixExpr,
-		lexer.TPlus:    p.parseInfixExpr,
-		lexer.TEqual:   p.parseInfixExpr,
-		lexer.TLessEq:  p.parseInfixExpr,
-		lexer.TLess:    p.parseInfixExpr,
-		lexer.TLParen:  p.parseFunCallExpr,
-		lexer.TLBrace:  p.parseIndexOrSliceExpr,
+		lexer.TDot:    p.parseFieldAccessExpr,
+		lexer.THyphen: p.parseInfixExpr,
+		lexer.TPlus:   p.parseInfixExpr,
+		lexer.TEqual:  p.parseInfixExpr,
+		lexer.TLessEq: p.parseInfixExpr,
+		lexer.TLess:   p.parseInfixExpr,
+		lexer.TLParen: p.parseFunCallExpr,
+		lexer.TLBrace: p.parseIndexOrSliceExpr,
 	}
 }
 
@@ -150,24 +151,28 @@ func (p *Parser) parseProgram() ([]ast.Stmt, error) {
 		if p.curToken.Type == lexer.TEOF {
 			break
 		}
-		stmt, err := p.parseToplevelStmt()
+		stmts, err := p.parseToplevelStmt()
 		if err != nil {
 			return nil, err
 		}
-		program = append(program, stmt)
+		program = append(program, stmts...)
 	}
 	return program, nil
 }
 
-func (p *Parser) parseToplevelStmt() (ast.Stmt, error) {
+func (p *Parser) parseToplevelStmt() ([]ast.Stmt, error) {
 	if p.curToken.Type == lexer.TTest {
-		return p.parseTestStmt()
+		stmt, err := p.parseTestStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	return p.parseStmt()
 }
 
-func (p *Parser) parseStmt() (ast.Stmt, error) {
+func (p *Parser) parseStmt() ([]ast.Stmt, error) {
 	if p.curToken.Type == lexer.TEOF {
 		return nil, fmt.Errorf("unexpected EOF")
 	}
@@ -175,11 +180,19 @@ func (p *Parser) parseStmt() (ast.Stmt, error) {
 	if p.curToken.Type == lexer.TIdent {
 		if p.peekToken.Type == lexer.TAssign {
 			// `x = expr` form
-			return p.parseVarAssignStmt()
+			stmt, err := p.parseVarAssignStmt()
+			if err != nil {
+				return nil, err
+			}
+			return []ast.Stmt{stmt}, nil
 		}
 		if p.peekToken.Type == lexer.TIncr || p.peekToken.Type == lexer.TDecr {
 			// `x += expr` or `x -= expr` form
-			return p.parseVarIncrDecrStmt()
+			stmt, err := p.parseVarIncrDecrStmt()
+			if err != nil {
+				return nil, err
+			}
+			return []ast.Stmt{stmt}, nil
 		}
 	}
 
@@ -188,27 +201,51 @@ func (p *Parser) parseStmt() (ast.Stmt, error) {
 	}
 
 	if p.curToken.Type == lexer.TWhile {
-		return p.parseWhileStmt()
+		stmt, err := p.parseWhileStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TIf {
-		return p.parseIfStmt()
+		stmt, err := p.parseIfStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TReturn {
-		return p.parseReturnStmt()
+		stmt, err := p.parseReturnStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TBreak {
-		return p.parseBreakStmt()
+		stmt, err := p.parseBreakStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TContinue {
-		return p.parseContinueStmt()
+		stmt, err := p.parseContinueStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TAssert {
-		return p.parseAssertStmt()
+		stmt, err := p.parseAssertStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	expr, err := p.parseExpr(PLowest)
@@ -216,20 +253,32 @@ func (p *Parser) parseStmt() (ast.Stmt, error) {
 		return nil, err
 	}
 
-	return &ast.ExprStmt{Expr: expr}, nil
+	return []ast.Stmt{&ast.ExprStmt{Expr: expr}}, nil
 }
 
-func (p *Parser) parseBodyStmt() (ast.Stmt, error) {
+func (p *Parser) parseBodyStmt() ([]ast.Stmt, error) {
 	if p.curToken.Type == lexer.TReturn {
-		return p.parseReturnStmt()
+		stmt, err := p.parseReturnStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TBreak {
-		return p.parseBreakStmt()
+		stmt, err := p.parseBreakStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	if p.curToken.Type == lexer.TContinue {
-		return p.parseContinueStmt()
+		stmt, err := p.parseContinueStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
 	}
 
 	return p.parseStmt()
@@ -247,11 +296,11 @@ func (p *Parser) parseBody() ([]ast.Stmt, error) {
 		if p.curToken.Type == lexer.TElse {
 			break
 		}
-		stmt, err := p.parseBodyStmt()
+		stmts, err := p.parseBodyStmt()
 		if err != nil {
 			return nil, err
 		}
-		body = append(body, stmt)
+		body = append(body, stmts...)
 	}
 	return body, nil
 }
@@ -290,10 +339,14 @@ func (p *Parser) parseReturnStmt() (*ast.ReturnStmt, error) {
 	}, nil
 }
 
-func (p *Parser) parseVarDeclStmt() (*ast.VarDeclStmt, error) {
+func (p *Parser) parseVarDeclStmt() ([]ast.Stmt, error) {
 	if err := p.expect(lexer.TLet); err != nil {
 		return nil, err
 	}
+	if p.curToken.Type == lexer.TLBracket { // '{'
+		return p.parseRecordDestructStmt()
+	}
+
 	name := p.curToken.Text
 	if err := p.expect(lexer.TIdent); err != nil {
 		return nil, err
@@ -305,10 +358,105 @@ func (p *Parser) parseVarDeclStmt() (*ast.VarDeclStmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ast.VarDeclStmt{
+	return []ast.Stmt{&ast.VarDeclStmt{
 		Name: name,
 		Body: body,
-	}, nil
+	}}, nil
+}
+
+func (p *Parser) parseRecordDestructStmt() ([]ast.Stmt, error) {
+	if err := p.expect(lexer.TLBracket); err != nil {
+		return nil, err
+	}
+
+	type field struct {
+		name  string
+		alias string
+	}
+	var fields []field
+	for {
+		if p.curToken.Type == lexer.TIdent {
+			name := p.curToken.Text
+			if err := p.readToken(); err != nil {
+				return nil, err
+			}
+			alias := ""
+			if p.curToken.Type == lexer.TAs {
+				if err := p.readToken(); err != nil {
+					return nil, err
+				}
+				if p.curToken.Type != lexer.TIdent {
+					return nil, fmt.Errorf("expected identifier after 'as', got %s", p.curToken.Type)
+				}
+				alias = p.curToken.Text
+				if err := p.readToken(); err != nil {
+					return nil, err
+				}
+			}
+			fields = append(fields, field{name: name, alias: alias})
+		}
+
+		if p.curToken.Type == lexer.TRBracket { // '}'
+			break
+		}
+
+		if err := p.expect(lexer.TComma); err != nil {
+			return nil, err
+		}
+
+		if p.curToken.Type == lexer.TRBracket { // '}'
+			break
+		}
+	}
+
+	if err := p.expect(lexer.TRBracket); err != nil {
+		return nil, err
+	}
+
+	if err := p.expect(lexer.TAssign); err != nil {
+		return nil, err
+	}
+
+	body, err := p.parseExpr(PLowest)
+	if err != nil {
+		return nil, err
+	}
+
+	var stmts []ast.Stmt
+	for _, f := range fields {
+		name := f.name
+		if f.alias != "" {
+			name = f.alias
+		}
+		stmts = append(stmts, &ast.VarDeclStmt{
+			Name: name,
+			Body: &ast.NullLiteralExpr{},
+		})
+	}
+
+	tempVar := fmt.Sprintf("$temp_%d", p.curToken.Pos.Start)
+	blockBody := []ast.Stmt{
+		&ast.VarDeclStmt{
+			Name: tempVar,
+			Body: body,
+		},
+	}
+	for _, f := range fields {
+		targetName := f.name
+		if f.alias != "" {
+			targetName = f.alias
+		}
+		blockBody = append(blockBody, &ast.AssignStmt{
+			Name: targetName,
+			Body: &ast.FieldAccessExpr{
+				Record: &ast.VarRefExpr{Name: tempVar},
+				Field:  f.name,
+			},
+		})
+	}
+	stmts = append(stmts, &ast.BlockStmt{Body: blockBody})
+
+	return stmts, nil
 }
 
 func (p *Parser) parseVarAssignStmt() (*ast.VarAssignStmt, error) {
@@ -658,6 +806,13 @@ func (p *Parser) parseIndexOrSliceExpr(left ast.Expr) (ast.Expr, error) {
 		Start: start,
 		End:   end,
 	}, nil
+}
+
+func (p *Parser) parseNullLiteralExpr() (ast.Expr, error) {
+	if err := p.readToken(); err != nil {
+		return nil, err
+	}
+	return &ast.NullLiteralExpr{}, nil
 }
 
 func (p *Parser) parseDigitLiteralExpr() (ast.Expr, error) {


### PR DESCRIPTION
## Description
This PR implements record destructuring and punning for `vvlang`, as proposed in [GitHub issue #15](https://github.com/fj68/vvlang/issues/15). 

The implementation uses a granular AST transformation approach. When the parser encounters a `let { ... } = expr` statement, it expands it into a sequence of more basic AST nodes. This allows for clean scope management for intermediate record values and better integration with the existing interpreter.

## Changes:
- **Lexer**: Added `as` and `null` keywords.
- **AST**: 
  - Added [BlockStmt](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/ast/stmt.go#93-96) for scoping groups of statements.
  - Added [AssignStmt](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/ast/stmt.go#84-88) for re-assigning values to existing variables.
  - Added [NullLiteralExpr](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/ast/expr.go#196-199) to represent the `null` value.
- **Parser**:
  - Refactored [parseStmt](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/parser/parser.go#175-266) to return `[]ast.Stmt`, allowing statement expansion.
  - Implemented transformation logic in [parseRecordDestructStmt](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/parser/parser.go#391-485).
  - Added support for `null` literal.
- **Interpreter**:
  - Added handling for [BlockStmt](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/ast/stmt.go#93-96), [AssignStmt](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/ast/stmt.go#84-88), and [NullLiteralExpr](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/ast/expr.go#196-199).
  - Added [VNull](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/interp/value.go#255-256) value type.
- **Tests**:
  - Added comprehensive tests for destructuring, punning, and aliasing in [interp/destruct_test.go](file:///c:/Users/fj68f/Documents/src/vvlang/vvlang/interp/destruct_test.go).

## Examples:
```vv
// Record destructuring with aliasing and punning
let { value as v, error } = f()
```
Expands to:
```vv
let v = null
let error = null
begin
  let $temp_pos = f()
  v = $temp_pos.value
  error = $temp_pos.error
end
```

## Verification:
- Ran `go test ./...` and confirmed all 4 tests in the new suite and all existing tests pass.
