### PR TITLE
Implement Block Scoping for If and While Statements

### DIFF
--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -34,33 +34,24 @@ func (stmt *ReturnStmt) Inspect() string {
 
 type WhileStmt struct {
 	Cond Expr
-	Body []Stmt
+	Body *BlockStmt
 }
 
 func (stmt *WhileStmt) Inspect() string {
-	var body []string
-	for _, s := range stmt.Body {
-		body = append(body, s.Inspect())
-	}
-	return fmt.Sprintf("WhileStmt{%s, %s}", stmt.Cond.Inspect(), strings.Join(body, ", "))
+	return fmt.Sprintf("WhileStmt{%s, %s}", stmt.Cond.Inspect(), stmt.Body)
 }
 
 type IfStmt struct {
 	Cond Expr
-	Then []Stmt
-	Else []Stmt
+	Then *BlockStmt
+	Else *BlockStmt
 }
 
 func (stmt *IfStmt) Inspect() string {
-	var thenBody []string
-	for _, s := range stmt.Then {
-		thenBody = append(thenBody, s.Inspect())
+	if stmt.Else == nil {
+		return fmt.Sprintf("IfStmt{%s, %s}", stmt.Cond.Inspect(), stmt.Then.Inspect())
 	}
-	var elseBody []string
-	for _, s := range stmt.Else {
-		elseBody = append(elseBody, s.Inspect())
-	}
-	return fmt.Sprintf("IfStmt{%s, %s, %s}", stmt.Cond.Inspect(), strings.Join(thenBody, ", "), strings.Join(elseBody, ", "))
+	return fmt.Sprintf("IfStmt{%s, %s, %s}", stmt.Cond.Inspect(), stmt.Then.Inspect(), stmt.Else.Inspect())
 }
 
 type VarAssignStmt struct {

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,123 @@
+diff --git a/interp/block_test.go b/interp/block_test.go
+new file mode 100644
+index 0000000..3980956
+--- /dev/null
++++ b/interp/block_test.go
+@@ -0,0 +1,46 @@
++package interp
++
++import (
++	"testing"
++)
++
++func TestBlockStmt(t *testing.T) {
++	tests := []struct {
++		input    string
++		expected string // if empty, no error expected
++	}{
++		{
++			input: `
++let x = 0
++begin
++  let y = 1
++  x += 1
++end
++// Here x should be 1, y should be undefined
++`,
++			expected: "",
++		},
++	}
++
++	for _, tt := range tests {
++		s := NewState()
++		err := s.Eval([]rune(tt.input))
++		if err != nil {
++			t.Errorf("Eval(%q) failed: %v", tt.input, err)
++		}
++
++		// Check x is 1
++		val, err := s.Env.Get("x")
++		if err != nil {
++			t.Errorf("expected x to be defined, got error: %v", err)
++		} else if float64(val.(VNumber)) != 1 {
++			t.Errorf("expected x=1, got %v", val)
++		}
++
++		// Check y is not defined
++		_, err = s.Env.Get("y")
++		if err == nil {
++			t.Errorf("expected y to be undefined, but it was found")
++		}
++	}
++}
+diff --git a/lexer/token.go b/lexer/token.go
+index 00e6765..b7e4a87 100644
+--- a/lexer/token.go
++++ b/lexer/token.go
+@@ -19,6 +19,7 @@ const (
+ 
+ 	// keywords
+ 	TFun
++	TBegin
+ 	TReturn
+ 	TEnd
+ 	TWhile
+@@ -78,6 +79,8 @@ func (ty TokenType) String() string {
+ 		// keywords
+ 	case TFun:
+ 		return "Fun"
++	case TBegin:
++		return "Begin"
+ 	case TReturn:
+ 		return "Return"
+ 	case TEnd:
+@@ -204,6 +207,7 @@ var Symbols2 = map[string]TokenType{
+ 
+ var Keywords = map[string]TokenType{
+ 	"fun":      TFun,
++	"begin":    TBegin,
+ 	"return":   TReturn,
+ 	"end":      TEnd,
+ 	"while":    TWhile,
+diff --git a/parser/parser.go b/parser/parser.go
+index 9be0e9c..230919e 100644
+--- a/parser/parser.go
++++ b/parser/parser.go
+@@ -200,6 +200,14 @@ func (p *Parser) parseStmt() ([]ast.Stmt, error) {
+ 		return p.parseVarDeclStmt()
+ 	}
+ 
++	if p.curToken.Type == lexer.TBegin {
++		stmt, err := p.parseBlockStmt()
++		if err != nil {
++			return nil, err
++		}
++		return []ast.Stmt{stmt}, nil
++	}
++
+ 	if p.curToken.Type == lexer.TWhile {
+ 		stmt, err := p.parseWhileStmt()
+ 		if err != nil {
+@@ -305,6 +313,22 @@ func (p *Parser) parseBody() ([]ast.Stmt, error) {
+ 	return body, nil
+ }
+ 
++func (p *Parser) parseBlockStmt() (*ast.BlockStmt, error) {
++	if err := p.expect(lexer.TBegin); err != nil {
++		return nil, err
++	}
++	body, err := p.parseBody()
++	if err != nil {
++		return nil, err
++	}
++	if err := p.expect(lexer.TEnd); err != nil {
++		return nil, err
++	}
++	return &ast.BlockStmt{
++		Body: body,
++	}, nil
++}
++
+ func (p *Parser) parseBreakStmt() (*ast.BreakStmt, error) {
+ 	if err := p.expect(lexer.TBreak); err != nil {
+ 		return nil, err

--- a/interp/scoping_test.go
+++ b/interp/scoping_test.go
@@ -1,0 +1,86 @@
+package interp
+
+import (
+	"testing"
+)
+
+func TestScoping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]float64
+		err      bool
+	}{
+		{
+			name: "if scoping",
+			input: `
+let x = 10
+if true
+  let x = 20
+  let y = 30
+end
+`,
+			expected: map[string]float64{"x": 10},
+		},
+		{
+			name: "while scoping",
+			input: `
+let x = 10
+let i = 0
+while i < 1
+  let x = 20
+  let y = 30
+  i = i + 1
+end
+`,
+			expected: map[string]float64{"x": 10},
+		},
+		{
+			name: "nested scoping",
+			input: `
+let x = 1
+if true
+  let x = 2
+  if true
+    let x = 3
+  end
+end
+`,
+			expected: map[string]float64{"x": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewState()
+			err := s.Eval([]rune(tt.input))
+			if (err != nil) != tt.err {
+				t.Fatalf("Eval() error = %v, wantErr %v", err, tt.err)
+			}
+
+			for varName, expectedVal := range tt.expected {
+				val, err := s.Env.Get(varName)
+				if err != nil {
+					t.Errorf("variable %s not found: %v", varName, err)
+					continue
+				}
+				num, ok := val.(VNumber)
+				if !ok {
+					t.Errorf("variable %s is not a number, got %T", varName, val)
+					continue
+				}
+				if float64(num) != expectedVal {
+					t.Errorf("variable %s = %v, want %v", varName, num, expectedVal)
+				}
+			}
+
+			// Verify local variables are NOT present
+			if tt.name == "if scoping" || tt.name == "while scoping" {
+				_, err := s.Env.Get("y")
+				if err == nil {
+					t.Errorf("variable y should be undefined out of scope")
+				}
+			}
+		})
+	}
+}

--- a/interp/state.go
+++ b/interp/state.go
@@ -157,12 +157,12 @@ func (s *State) evalIfStmt(stmt *ast.IfStmt) error {
 		return fmt.Errorf("expected bool, but got %s", v.Type())
 	}
 	if cond {
-		return s.evalBody(stmt.Then)
+		return s.evalStmt(stmt.Then)
 	}
 	if stmt.Else == nil {
 		return nil
 	}
-	return s.evalBody(stmt.Else)
+	return s.evalStmt(stmt.Else)
 }
 
 func (s *State) evalExprStmt(stmt *ast.ExprStmt) error {
@@ -328,23 +328,15 @@ func (s *State) evalWhileStmt(stmt *ast.WhileStmt) error {
 		if !cond {
 			break
 		}
-		for _, st := range stmt.Body {
-			err := s.evalStmt(st)
-			if err == ErrContinue {
-				// continue to next iteration
-				break
-			}
-			if err == ErrBreak {
-				// exit the while loop
-				return nil
-			}
-			if err == ErrReturn {
-				// propagate return up
-				return ErrReturn
-			}
-			if err != nil {
-				return err
-			}
+		err = s.evalStmt(stmt.Body)
+		if err == ErrBreak {
+			return nil
+		}
+		if err == ErrReturn {
+			return ErrReturn
+		}
+		if err != nil && err != ErrContinue {
+			return err
 		}
 	}
 	return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -557,7 +557,7 @@ func (p *Parser) parseWhileStmt() (*ast.WhileStmt, error) {
 	}
 	return &ast.WhileStmt{
 		Cond: cond,
-		Body: body,
+		Body: &ast.BlockStmt{Body: body},
 	}, nil
 }
 
@@ -573,22 +573,23 @@ func (p *Parser) parseIfStmt() (*ast.IfStmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	var elseBody []ast.Stmt
+	var elseBody *ast.BlockStmt
 	if p.curToken.Type == lexer.TElse {
 		if err := p.readToken(); err != nil {
 			return nil, err
 		}
-		elseBody, err = p.parseBody()
+		eBody, err := p.parseBody()
 		if err != nil {
 			return nil, err
 		}
+		elseBody = &ast.BlockStmt{Body: eBody}
 	}
 	if err := p.expect(lexer.TEnd); err != nil {
 		return nil, err
 	}
 	return &ast.IfStmt{
 		Cond: cond,
-		Then: thenBody,
+		Then: &ast.BlockStmt{Body: thenBody},
 		Else: elseBody,
 	}, nil
 }


### PR DESCRIPTION
This PR updates `if` and `while` statements to use `BlockStmt` as their body, introducing proper lexical scoping. Variables declared with `let` inside an `if` or `while` block will now be local to that block.

Key Changes:
- `ast.IfStmt` and `ast.WhileStmt` now have `*ast.BlockStmt` children instead of `[]ast.Stmt`.
- The parser now automatically constructs these blocks.
- The interpreter leverages the existing `BlockStmt` environment management.