### PR TITLE
feat: add 'defer' syntax and fix missing arithmetic operators

### DIFF
--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -121,3 +121,11 @@ type AssertStmt struct {
 func (stmt *AssertStmt) Inspect() string {
 	return fmt.Sprintf("AssertStmt{%s}", stmt.Cond.Inspect())
 }
+
+type DeferStmt struct {
+	Body Expr
+}
+
+func (stmt *DeferStmt) Inspect() string {
+	return fmt.Sprintf("DeferStmt{%s}", stmt.Body.Inspect())
+}

--- a/interp/defer_test.go
+++ b/interp/defer_test.go
@@ -1,0 +1,140 @@
+package interp
+
+import (
+	"testing"
+)
+
+func TestDefer(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]float64
+	}{
+		{
+			name: "basic defer",
+			input: `
+let x = 1
+let f = fun() x = 2 end
+begin
+  defer f()
+  x = 3
+end
+`,
+			expected: map[string]float64{"x": 2},
+		},
+		{
+			name: "multiple defers (LIFO)",
+			input: `
+let x = 1
+let f1 = fun() x = x * 2 end
+let f2 = fun() x = x + 1 end
+begin
+  defer f1()
+  defer f2()
+  x = 10
+end
+`,
+			// x = 10
+			// defer f2() -> x = 11
+			// defer f1() -> x = 22
+			expected: map[string]float64{"x": 22},
+		},
+		{
+			name: "defer in if",
+			input: `
+let x = 1
+let f = fun() x = 2 end
+if true
+  defer f()
+  x = 3
+end
+`,
+			expected: map[string]float64{"x": 2},
+		},
+		{
+			name: "defer in false if",
+			input: `
+let x = 1
+let f = fun() x = 2 end
+if false
+  defer f()
+  x = 3
+end
+`,
+			expected: map[string]float64{"x": 1},
+		},
+		{
+			name: "defer in while",
+			input: `
+let x = 0
+let i = 0
+let f = fun() x = x + 1 end
+while i < 3
+  defer f()
+  i = i + 1
+end
+`,
+			// Each iteration has its own defer scope.
+			// Iteration 1: defer f() -> x = 1
+			// Iteration 2: defer f() -> x = 2
+			// Iteration 3: defer f() -> x = 3
+			expected: map[string]float64{"x": 3},
+		},
+		{
+			name: "defer in function",
+			input: `
+let x = 1
+let f_defer = fun() x = 2 end
+let f = fun()
+  defer f_defer()
+  x = 3
+end
+f()
+`,
+			expected: map[string]float64{"x": 2},
+		},
+		{
+			name: "nested blocks",
+			input: `
+let x = 0
+let f1 = fun() x = x + 1 end
+let f10 = fun() x = x + 10 end
+begin
+  defer f1()
+  begin
+    defer f10()
+    x = 100
+  end
+end
+`,
+			expected: map[string]float64{"x": 111},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewState()
+			s.RegisterGlobals(DefaultBuiltins) // ensure builtins are available if needed
+			err := s.Eval([]rune(tt.input))
+			if err != nil {
+				t.Fatalf("Eval() error = %v", err)
+			}
+
+			for varName, expectedVal := range tt.expected {
+				val, err := s.Env.Get(varName)
+				if err != nil {
+					t.Errorf("variable %s not found: %v", varName, err)
+					continue
+				}
+				num, ok := val.(VNumber)
+				if !ok {
+					t.Errorf("variable %s is not a number, got %T", varName, val)
+					continue
+				}
+				if float64(num) != expectedVal {
+					t.Errorf("variable %s = %v, want %v", varName, num, expectedVal)
+				}
+			}
+		})
+	}
+}

--- a/interp/state.go
+++ b/interp/state.go
@@ -12,6 +12,7 @@ type State struct {
 	IsTestMode bool
 	Env        *Env
 	RetVals    stack.Stack[Value]
+	Defers     [][]ast.Expr
 }
 
 func NewState() *State {
@@ -59,12 +60,41 @@ func (s *State) popEnv() {
 	s.Env = s.Env.outer
 }
 
+func (s *State) pushDeferScope() {
+	s.Defers = append(s.Defers, []ast.Expr{})
+}
+
+func (s *State) popDeferScope() error {
+	if len(s.Defers) == 0 {
+		return nil
+	}
+	scope := s.Defers[len(s.Defers)-1]
+	s.Defers = s.Defers[:len(s.Defers)-1]
+
+	// Execute defers in LIFO order
+	for i := len(scope) - 1; i >= 0; i-- {
+		_, err := s.evalExpr(scope[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var ErrBreak = fmt.Errorf("break")
 var ErrContinue = fmt.Errorf("continue")
 var ErrReturn = fmt.Errorf("return")
 
-func (s *State) evalTestProgram(program []ast.Stmt) error {
+func (s *State) evalTestProgram(program []ast.Stmt) (err error) {
 	s.IsTestMode = true
+	s.pushDeferScope()
+	defer func() {
+		deferErr := s.popDeferScope()
+		if err == nil {
+			err = deferErr
+		}
+	}()
+
 	for _, stmt := range program {
 		if _, ok := stmt.(*ast.TestStmt); !ok {
 			// run only test stmts, and skip other top-level stmts during test evaluation
@@ -81,7 +111,15 @@ func (s *State) evalTestProgram(program []ast.Stmt) error {
 	return nil
 }
 
-func (s *State) evalProgram(program []ast.Stmt) error {
+func (s *State) evalProgram(program []ast.Stmt) (err error) {
+	s.pushDeferScope()
+	defer func() {
+		deferErr := s.popDeferScope()
+		if err == nil {
+			err = deferErr
+		}
+	}()
+
 	for _, stmt := range program {
 		if err := s.evalStmt(stmt); err != nil {
 			if err == ErrReturn {
@@ -129,6 +167,8 @@ func (s *State) evalStmt(stmt ast.Stmt) error {
 		return s.evalTestStmt(v)
 	case *ast.AssertStmt:
 		return s.evalAssertStmt(v)
+	case *ast.DeferStmt:
+		return s.evalDeferStmt(v)
 	default:
 		return fmt.Errorf("unknown stmt: %s", v.Inspect())
 	}
@@ -191,9 +231,17 @@ func (s *State) evalAssignStmt(stmt *ast.AssignStmt) error {
 	return nil
 }
 
-func (s *State) evalBlockStmt(stmt *ast.BlockStmt) error {
+func (s *State) evalBlockStmt(stmt *ast.BlockStmt) (err error) {
 	s.pushEnv()
 	defer s.popEnv()
+
+	s.pushDeferScope()
+	defer func() {
+		deferErr := s.popDeferScope()
+		if err == nil {
+			err = deferErr
+		}
+	}()
 
 	return s.evalBody(stmt.Body)
 }
@@ -296,13 +344,21 @@ func (s *State) evalArgs(exprs []ast.Expr) ([]Value, error) {
 	return args, nil
 }
 
-func (s *State) callUserFun(f *VUserFun, args []Value) (Value, error) {
+func (s *State) callUserFun(f *VUserFun, args []Value) (val Value, err error) {
 	if len(f.Args) != len(args) {
 		return nil, fmt.Errorf("not enough or too much arguments")
 	}
 
 	s.pushEnv()
 	defer s.popEnv()
+
+	s.pushDeferScope()
+	defer func() {
+		deferErr := s.popDeferScope()
+		if err == nil {
+			err = deferErr
+		}
+	}()
 
 	for i, arg := range args {
 		s.Env.Values[f.Args[i]] = arg
@@ -364,6 +420,12 @@ func (s *State) evalInfixExpr(expr *ast.InfixExpr) (Value, error) {
 	switch expr.Op {
 	case "+":
 		return s.evalAddExpr(left, right)
+	case "-":
+		return s.evalSubExpr(left, right)
+	case "*":
+		return s.evalMulExpr(left, right)
+	case "/":
+		return s.evalDivExpr(left, right)
 	case "==":
 		return s.evalEqualExpr(left, right)
 	case "<":
@@ -389,6 +451,45 @@ func (s *State) evalAddExpr(left Value, right Value) (Value, error) {
 		return nil, fmt.Errorf("right side value of add expression is not a number")
 	}
 	return VNumber(lvalue + rvalue), nil
+}
+
+func (s *State) evalSubExpr(left Value, right Value) (Value, error) {
+	lvalue, ok := left.(VNumber)
+	if !ok {
+		return nil, fmt.Errorf("left side value of sub expression is not a number")
+	}
+	rvalue, ok := right.(VNumber)
+	if !ok {
+		return nil, fmt.Errorf("right side value of sub expression is not a number")
+	}
+	return VNumber(lvalue - rvalue), nil
+}
+
+func (s *State) evalMulExpr(left Value, right Value) (Value, error) {
+	lvalue, ok := left.(VNumber)
+	if !ok {
+		return nil, fmt.Errorf("left side value of mul expression is not a number")
+	}
+	rvalue, ok := right.(VNumber)
+	if !ok {
+		return nil, fmt.Errorf("right side value of mul expression is not a number")
+	}
+	return VNumber(lvalue * rvalue), nil
+}
+
+func (s *State) evalDivExpr(left Value, right Value) (Value, error) {
+	lvalue, ok := left.(VNumber)
+	if !ok {
+		return nil, fmt.Errorf("left side value of div expression is not a number")
+	}
+	rvalue, ok := right.(VNumber)
+	if !ok {
+		return nil, fmt.Errorf("right side value of div expression is not a number")
+	}
+	if rvalue == 0 {
+		return nil, fmt.Errorf("division by zero")
+	}
+	return VNumber(lvalue / rvalue), nil
 }
 
 func (s *State) evalEqualExpr(left Value, right Value) (Value, error) {
@@ -663,5 +764,13 @@ func (s *State) evalTestStmt(stmt *ast.TestStmt) error {
 	if s.IsTestMode {
 		return s.evalBody(stmt.Body)
 	}
+	return nil
+}
+
+func (s *State) evalDeferStmt(stmt *ast.DeferStmt) error {
+	if len(s.Defers) == 0 {
+		return fmt.Errorf("no defer scope available")
+	}
+	s.Defers[len(s.Defers)-1] = append(s.Defers[len(s.Defers)-1], stmt.Body)
 	return nil
 }

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -38,6 +38,7 @@ const (
 	TAssert
 	TAs
 	TNull
+	TDefer
 
 	// symbols
 	TLessEq
@@ -117,6 +118,8 @@ func (ty TokenType) String() string {
 		return "As"
 	case TNull:
 		return "Null"
+	case TDefer:
+		return "Defer"
 
 	// symbols
 	case TLessEq:
@@ -226,6 +229,7 @@ var Keywords = map[string]TokenType{
 	"assert":   TAssert,
 	"as":       TAs,
 	"null":     TNull,
+	"defer":    TDefer,
 }
 
 var Comments = map[string]string{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -93,14 +93,16 @@ func (p *Parser) registerPrefixParsers() {
 
 func (p *Parser) registerInfixParsers() {
 	p.infixParsers = map[lexer.TokenType]InfixParser{
-		lexer.TDot:    p.parseFieldAccessExpr,
-		lexer.THyphen: p.parseInfixExpr,
-		lexer.TPlus:   p.parseInfixExpr,
-		lexer.TEqual:  p.parseInfixExpr,
-		lexer.TLessEq: p.parseInfixExpr,
-		lexer.TLess:   p.parseInfixExpr,
-		lexer.TLParen: p.parseFunCallExpr,
-		lexer.TLBrace: p.parseIndexOrSliceExpr,
+		lexer.TDot:      p.parseFieldAccessExpr,
+		lexer.THyphen:   p.parseInfixExpr,
+		lexer.TPlus:     p.parseInfixExpr,
+		lexer.TEqual:    p.parseInfixExpr,
+		lexer.TLessEq:   p.parseInfixExpr,
+		lexer.TLess:     p.parseInfixExpr,
+		lexer.TLParen:   p.parseFunCallExpr,
+		lexer.TLBrace:   p.parseIndexOrSliceExpr,
+		lexer.TAsterisk: p.parseInfixExpr,
+		lexer.TSlash:    p.parseInfixExpr,
 	}
 }
 
@@ -256,6 +258,14 @@ func (p *Parser) parseStmt() ([]ast.Stmt, error) {
 		return []ast.Stmt{stmt}, nil
 	}
 
+	if p.curToken.Type == lexer.TDefer {
+		stmt, err := p.parseDeferStmt()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Stmt{stmt}, nil
+	}
+
 	expr, err := p.parseExpr(PLowest)
 	if err != nil {
 		return nil, err
@@ -341,6 +351,17 @@ func (p *Parser) parseContinueStmt() (*ast.ContinueStmt, error) {
 		return nil, err
 	}
 	return &ast.ContinueStmt{}, nil
+}
+
+func (p *Parser) parseDeferStmt() (*ast.DeferStmt, error) {
+	if err := p.expect(lexer.TDefer); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr(PLowest)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.DeferStmt{Body: expr}, nil
 }
 
 func (p *Parser) parseReturnStmt() (*ast.ReturnStmt, error) {


### PR DESCRIPTION
# Description
This PR adds the 'defer' syntax to 'vvlang'. Unlike Go, 'defer' in 'vvlang' is block-level, meaning deferred expressions are executed at the end of the containing block, loop iteration, or function call. 

Additionally, this PR fixes some missing arithmetic operators ('*', '/', '-') in both the parser and interpreter that were uncovered during testing.

## Changes Made
- **Lexer**: Added 'TDefer' token and recognized the 'defer' keyword.
- **AST**: Added 'DeferStmt' node (with an 'Expr' body).
- **Parser**: Implemented 'parseDeferStmt' and added missing infix parsers for '*' and '/'.
- **Interpreter**: 
    - Implemented a 'Defers' stack in 'State' to handle nested defer scopes.
    - Updated execution logic for blocks, programs, and functions to process deferred expressions in LIFO order.
    - Added evaluation logic for '*', '/', and '-' operators.

## Verification
Comprehensive tests were added in 'interp/defer_test.go', covering:
- Basic 'defer' usage.
- LIFO execution order.
- Scoping in 'if'/'while' blocks and function calls.
- Nested block behavior.

All tests passed successfully.