### PR TITLE
Implement 'extern' keyword

### DIFF
--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -129,3 +129,12 @@ type DeferStmt struct {
 func (stmt *DeferStmt) Inspect() string {
 	return fmt.Sprintf("DeferStmt{%s}", stmt.Body.Inspect())
 }
+
+type ExternStmt struct {
+	Type string // e.g. "native"
+	Name string
+}
+
+func (stmt *ExternStmt) Inspect() string {
+	return fmt.Sprintf("ExternStmt{\"%s\", \"%s\"}", stmt.Type, stmt.Name)
+}

--- a/interp/extern_test.go
+++ b/interp/extern_test.go
@@ -1,0 +1,69 @@
+package interp
+
+import (
+	"testing"
+)
+
+func TestExtern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		globals map[string]Value
+		wantErr bool
+	}{
+		{
+			name:  "valid extern fun",
+			input: "extern 'native' fun f() f()",
+			globals: map[string]Value{
+				"f": VBuiltinFun(func(s *State, args []Value) (Value, error) {
+					return VNumber(42), nil
+				}),
+			},
+			wantErr: false,
+		},
+		{
+			name:  "valid extern let",
+			input: "extern 'native' let v v + 1",
+			globals: map[string]Value{
+				"v": VNumber(10),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "extern missing name",
+			input:   "extern 'native' fun g() g()",
+			globals: map[string]Value{},
+			wantErr: true,
+		},
+		{
+			name:    "extern invalid placement",
+			input:   "let x = 1 extern 'native' let v x + v",
+			globals: map[string]Value{"v": VNumber(1)},
+			wantErr: true,
+		},
+		{
+			name:  "extern fun with args",
+			input: "extern 'native' fun add(a, b) add(1, 2)",
+			globals: map[string]Value{
+				"add": VBuiltinFun(func(s *State, args []Value) (Value, error) {
+					if len(args) != 2 {
+						return nil, nil
+					}
+					return VNumber(float64(args[0].(VNumber) + args[1].(VNumber))), nil
+				}),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewState()
+			s.RegisterGlobals(tt.globals)
+			err := s.Eval([]rune(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Eval() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/interp/state.go
+++ b/interp/state.go
@@ -169,6 +169,8 @@ func (s *State) evalStmt(stmt ast.Stmt) error {
 		return s.evalAssertStmt(v)
 	case *ast.DeferStmt:
 		return s.evalDeferStmt(v)
+	case *ast.ExternStmt:
+		return s.evalExternStmt(v)
 	default:
 		return fmt.Errorf("unknown stmt: %s", v.Inspect())
 	}
@@ -772,5 +774,13 @@ func (s *State) evalDeferStmt(stmt *ast.DeferStmt) error {
 		return fmt.Errorf("no defer scope available")
 	}
 	s.Defers[len(s.Defers)-1] = append(s.Defers[len(s.Defers)-1], stmt.Body)
+	return nil
+}
+func (s *State) evalExternStmt(stmt *ast.ExternStmt) error {
+	_, err := s.Env.Get(stmt.Name)
+	if err != nil {
+		return fmt.Errorf("extern: %s", err)
+	}
+	// success: the name is provided by the environment
 	return nil
 }

--- a/lexer/extern_lexer_test.go
+++ b/lexer/extern_lexer_test.go
@@ -1,0 +1,23 @@
+package lexer
+
+import (
+	"testing"
+)
+
+func TestLexerExtern(t *testing.T) {
+	text := "extern 'native' fun f(a, b) extern 'native' let v"
+	expected := []TokenType{
+		TExtern, TLiteral, TFun, TIdent, TLParen, TIdent, TComma, TIdent, TRParen,
+		TExtern, TLiteral, TLet, TIdent,
+	}
+	lex := New([]rune(text))
+	for i, exp := range expected {
+		tok, err := lex.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok.Type != exp {
+			t.Fatalf("%d: expected %v, but got %v", i, exp, tok.Type)
+		}
+	}
+}

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -39,6 +39,7 @@ const (
 	TAs
 	TNull
 	TDefer
+	TExtern
 
 	// symbols
 	TLessEq
@@ -120,6 +121,8 @@ func (ty TokenType) String() string {
 		return "Null"
 	case TDefer:
 		return "Defer"
+	case TExtern:
+		return "Extern"
 
 	// symbols
 	case TLessEq:
@@ -230,6 +233,7 @@ var Keywords = map[string]TokenType{
 	"as":       TAs,
 	"null":     TNull,
 	"defer":    TDefer,
+	"extern":   TExtern,
 }
 
 var Comments = map[string]string{

--- a/parser/extern_parser_test.go
+++ b/parser/extern_parser_test.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParserExtern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "valid extern fun",
+			input:   "extern 'native' fun f(a, b)",
+			wantErr: false,
+		},
+		{
+			name:    "valid extern let",
+			input:   "extern 'native' let v",
+			wantErr: false,
+		},
+		{
+			name:    "multiple valid extern statements",
+			input:   "extern 'native' fun f1()\nextern 'native' let v1\nextern 'native' fun f2()",
+			wantErr: false,
+		},
+		{
+			name:    "invalid extern placement",
+			input:   "let x = 1\nextern 'native' let v",
+			wantErr: true,
+		},
+		{
+			name:    "invalid extern syntax - missing literal",
+			input:   "extern fun f()",
+			wantErr: true,
+		},
+		{
+			name:    "invalid extern syntax - missing fun/let",
+			input:   "extern 'native' f()",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]rune(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -149,9 +149,18 @@ func (p *Parser) parseProgram() ([]ast.Stmt, error) {
 	}
 
 	var program []ast.Stmt
+	header, err := p.parseProgramHeader()
+	if err != nil {
+		return nil, err
+	}
+	program = append(program, header...)
+
 	for {
 		if p.curToken.Type == lexer.TEOF {
 			break
+		}
+		if p.curToken.Type == lexer.TExtern {
+			return nil, fmt.Errorf("extern statement must be at the beginning of the program")
 		}
 		stmts, err := p.parseToplevelStmt()
 		if err != nil {
@@ -160,6 +169,22 @@ func (p *Parser) parseProgram() ([]ast.Stmt, error) {
 		program = append(program, stmts...)
 	}
 	return program, nil
+}
+
+func (p *Parser) parseProgramHeader() ([]ast.Stmt, error) {
+	var header []ast.Stmt
+	for {
+		if p.curToken.Type == lexer.TExtern {
+			stmt, err := p.parseExternStmt()
+			if err != nil {
+				return nil, err
+			}
+			header = append(header, stmt)
+			continue
+		}
+		break
+	}
+	return header, nil
 }
 
 func (p *Parser) parseToplevelStmt() ([]ast.Stmt, error) {
@@ -305,14 +330,11 @@ func (p *Parser) parseBodyStmt() ([]ast.Stmt, error) {
 func (p *Parser) parseBody() ([]ast.Stmt, error) {
 	var body []ast.Stmt
 	for {
-		if p.curToken.Type == lexer.TEOF {
+		switch p.curToken.Type {
+		case lexer.TEOF:
 			return nil, fmt.Errorf("unexpected eof while reading body")
-		}
-		if p.curToken.Type == lexer.TEnd {
-			break
-		}
-		if p.curToken.Type == lexer.TElse {
-			break
+		case lexer.TEnd, lexer.TElse:
+			return body, nil
 		}
 		stmts, err := p.parseBodyStmt()
 		if err != nil {
@@ -320,7 +342,6 @@ func (p *Parser) parseBody() ([]ast.Stmt, error) {
 		}
 		body = append(body, stmts...)
 	}
-	return body, nil
 }
 
 func (p *Parser) parseBlockStmt() (*ast.BlockStmt, error) {
@@ -362,6 +383,51 @@ func (p *Parser) parseDeferStmt() (*ast.DeferStmt, error) {
 		return nil, err
 	}
 	return &ast.DeferStmt{Body: expr}, nil
+}
+
+func (p *Parser) parseExternStmt() (*ast.ExternStmt, error) {
+	if err := p.expect(lexer.TExtern); err != nil {
+		return nil, err
+	}
+
+	extType := p.curToken.Text
+	if err := p.expect(lexer.TLiteral); err != nil {
+		return nil, err
+	}
+
+	var name string
+	switch p.curToken.Type {
+	case lexer.TFun:
+		if err := p.readToken(); err != nil {
+			return nil, err
+		}
+		name = p.curToken.Text
+		if err := p.expect(lexer.TIdent); err != nil {
+			return nil, err
+		}
+		if p.curToken.Type != lexer.TLParen {
+			return nil, fmt.Errorf("expected '(', but got %s", p.curToken.Type)
+		}
+		_, err := p.parseFunLiteralArgs()
+		if err != nil {
+			return nil, err
+		}
+	case lexer.TLet:
+		if err := p.readToken(); err != nil {
+			return nil, err
+		}
+		name = p.curToken.Text
+		if err := p.expect(lexer.TIdent); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("expected 'fun' or 'let' after extern literal, but got %s", p.curToken.Type)
+	}
+
+	return &ast.ExternStmt{
+		Type: extType,
+		Name: name,
+	}, nil
 }
 
 func (p *Parser) parseReturnStmt() (*ast.ReturnStmt, error) {
@@ -798,12 +864,13 @@ func (p *Parser) parseIndexOrSliceExpr(left ast.Expr) (ast.Expr, error) {
 	var end ast.Expr
 
 	// If we see a colon right away, start is nil and we have a slice like [:end]
-	if p.curToken.Type == lexer.TColon {
+	switch p.curToken.Type {
+	case lexer.TColon:
 		// start is nil
-	} else if p.curToken.Type == lexer.TRBrace {
+	case lexer.TRBrace:
 		// Empty brackets [] - error
 		return nil, fmt.Errorf("expected index or slice expression")
-	} else {
+	default:
 		// Parse the first expression
 		expr, err := p.parseExpr(PLowest)
 		if err != nil {


### PR DESCRIPTION
Implement 'extern' keyword to support declaring external functions and variables from the host environment. Includes syntax support, placement validation (must be at start of program), and interpreter validation of symbol existence. Added unit tests for lexer, parser, and interpreter.