### PR TITLE
Implement module system: pub, import, and relative path support

### DIFF
--- a/ast/expr.go
+++ b/ast/expr.go
@@ -84,7 +84,6 @@ func (expr *InterpolatedStringLiteralExpr) Inspect() string {
 
 type FunLiteralExpr struct {
 	Position
-	Name string
 	Args []string
 	Body []Stmt
 }
@@ -94,7 +93,7 @@ func (expr *FunLiteralExpr) Inspect() string {
 	for _, s := range expr.Body {
 		body = append(body, s.Inspect())
 	}
-	return fmt.Sprintf("FunLiteralExpr{\"%s\", [%s], [%s]}", expr.Name, strings.Join(expr.Args, ", "), strings.Join(body, ", "))
+	return fmt.Sprintf("FunLiteralExpr{[%s], [%s]}", strings.Join(expr.Args, ", "), strings.Join(body, ", "))
 }
 
 type FunCallExpr struct {

--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -64,8 +64,9 @@ func (stmt *VarAssignStmt) Inspect() string {
 }
 
 type VarDeclStmt struct {
-	Name string
-	Body Expr
+	Name     string
+	Body     Expr
+	Exported bool
 }
 
 func (stmt *VarDeclStmt) Inspect() string {
@@ -131,10 +132,33 @@ func (stmt *DeferStmt) Inspect() string {
 }
 
 type ExternStmt struct {
-	Type string // e.g. "native"
-	Name string
+	Type     string // e.g. "native"
+	Name     string
+	Exported bool
 }
 
 func (stmt *ExternStmt) Inspect() string {
 	return fmt.Sprintf("ExternStmt{\"%s\", \"%s\"}", stmt.Type, stmt.Name)
+}
+
+type ImportStmt struct {
+	Alias string
+	Path  string
+}
+
+func (stmt *ImportStmt) Inspect() string {
+	return fmt.Sprintf("ImportStmt{\"%s\", \"%s\"}", stmt.Alias, stmt.Path)
+}
+
+type Module struct {
+	Statements []Stmt
+	Exports    map[string]Stmt
+}
+
+func (m *Module) Inspect() string {
+	var body []string
+	for _, s := range m.Statements {
+		body = append(body, s.Inspect())
+	}
+	return fmt.Sprintf("Module{[%s]}", strings.Join(body, ", "))
 }

--- a/interp/block_test.go
+++ b/interp/block_test.go
@@ -23,7 +23,7 @@ end
 	}
 
 	for _, tt := range tests {
-		s := NewState()
+		s := NewState("test.vv")
 		err := s.Eval([]rune(tt.input))
 		if err != nil {
 			t.Errorf("Eval(%q) failed: %v", tt.input, err)

--- a/interp/defer_test.go
+++ b/interp/defer_test.go
@@ -113,7 +113,7 @@ end
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := NewState("test.vv")
 			s.RegisterGlobals(DefaultBuiltins) // ensure builtins are available if needed
 			err := s.Eval([]rune(tt.input))
 			if err != nil {

--- a/interp/destruct_test.go
+++ b/interp/destruct_test.go
@@ -50,7 +50,7 @@ return { v = value, e = error }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := NewState("test.vv")
 			if err := s.Eval([]rune(tt.input)); err != nil {
 				t.Fatal(err)
 			}
@@ -93,7 +93,7 @@ func TestRecordDestructuringError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := NewState("test.vv")
 			err := s.Eval([]rune(tt.input))
 			if err == nil {
 				t.Fatal("expected error but got nil")

--- a/interp/extern_test.go
+++ b/interp/extern_test.go
@@ -58,7 +58,7 @@ func TestExtern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := NewState("test.vv")
 			s.RegisterGlobals(tt.globals)
 			err := s.Eval([]rune(tt.input))
 			if (err != nil) != tt.wantErr {

--- a/interp/list_test.go
+++ b/interp/list_test.go
@@ -3,7 +3,7 @@ package interp
 import "testing"
 
 func TestListLiteralEval(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "return [0, 1, 2]"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -28,7 +28,7 @@ func TestListLiteralEval(t *testing.T) {
 }
 
 func TestListLiteralEvalTrailingComma(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "return [0, 1, 2, ]"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func TestListLiteralEvalTrailingComma(t *testing.T) {
 }
 
 func TestListLiteralEmpty(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "return []"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -60,7 +60,7 @@ func TestListLiteralEmpty(t *testing.T) {
 }
 
 func TestListLiteralMixed(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "return [42, 'hello', true]"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)

--- a/interp/module_test.go
+++ b/interp/module_test.go
@@ -1,0 +1,165 @@
+package interp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestModuleImport(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// math.vv
+	mathPath := filepath.Join(tmpDir, "math.vv")
+	mathCode := `
+pub let pi = 3.14
+pub fun square(x) return x * x end
+let secret = 42
+`
+	if err := os.WriteFile(mathPath, []byte(mathCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// main.vv
+	mainPath := filepath.Join(tmpDir, "main.vv")
+	mainCode := `
+import math from './math.vv'
+return math.square(math.pi)
+`
+	if err := os.WriteFile(mainPath, []byte(mainCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewState(mainPath)
+	if err := s.Eval([]rune(mainCode)); err != nil {
+		t.Fatal(err)
+	}
+
+	res := s.RetVals.Pop()
+	num, ok := res.(VNumber)
+	if !ok {
+		t.Fatalf("expected VNumber, got %T", res)
+	}
+	expected := 3.14 * 3.14
+	if float64(num) != expected {
+		t.Fatalf("expected %v, got %v", expected, num)
+	}
+}
+
+func TestModuleVisibility(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// math.vv
+	mathPath := filepath.Join(tmpDir, "math.vv")
+	mathCode := `
+pub let pi = 3.14
+let secret = 42
+`
+	if err := os.WriteFile(mathPath, []byte(mathCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// main.vv
+	mainPath := filepath.Join(tmpDir, "main.vv")
+	mainCode := `
+import math from './math.vv'
+return math.secret
+`
+	if err := os.WriteFile(mainPath, []byte(mainCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewState(mainPath)
+	err := s.Eval([]rune(mainCode))
+	if err == nil {
+		t.Fatal("expected error accessing non-exported symbol, but got nil")
+	}
+}
+
+func TestNestedImport(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// constants.vv
+	constPath := filepath.Join(tmpDir, "constants.vv")
+	constCode := `pub let pi = 3.14`
+	if err := os.WriteFile(constPath, []byte(constCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// math.vv
+	mathPath := filepath.Join(tmpDir, "math.vv")
+	mathCode := `
+import c from './constants.vv'
+pub fun circle_area(r) return c.pi * r * r end
+`
+	if err := os.WriteFile(mathPath, []byte(mathCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// main.vv
+	mainPath := filepath.Join(tmpDir, "main.vv")
+	mainCode := `
+import math from './math.vv'
+return math.circle_area(2)
+`
+	if err := os.WriteFile(mainPath, []byte(mainCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewState(mainPath)
+	if err := s.Eval([]rune(mainCode)); err != nil {
+		t.Fatal(err)
+	}
+
+	res := s.RetVals.Pop()
+	num, ok := res.(VNumber)
+	if !ok {
+		t.Fatalf("expected VNumber, got %T", res)
+	}
+	expected := 3.14 * 2 * 2
+	if float64(num) != expected {
+		t.Fatalf("expected %v, got %v", expected, num)
+	}
+}
+
+func TestCyclicImport(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// a.vv
+	aPath := filepath.Join(tmpDir, "a.vv")
+	aCode := `import b from './b.vv'
+pub let val = 1`
+	if err := os.WriteFile(aPath, []byte(aCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// b.vv
+	bPath := filepath.Join(tmpDir, "b.vv")
+	bCode := `import a from './a.vv'
+pub let val = 2`
+	if err := os.WriteFile(bPath, []byte(bCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewState(aPath)
+	err := s.Eval([]rune(aCode))
+	if err == nil {
+		t.Fatal("expected error for cyclic dependency, but got nil")
+	}
+	if !contains(err.Error(), "cyclic dependency") {
+		t.Fatalf("expected 'cyclic dependency' error, got: %v", err)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || find(s, substr))
+}
+
+func find(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/interp/record_test.go
+++ b/interp/record_test.go
@@ -3,7 +3,7 @@ package interp
 import "testing"
 
 func TestRecordLiteralEval(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "return { name = 'value', key = 8 }"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestRecordLiteralEval(t *testing.T) {
 }
 
 func TestRecordLiteralEvalTrailingComma(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "return { name = 'value', key = 8, }"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -56,7 +56,7 @@ func TestRecordLiteralEvalTrailingComma(t *testing.T) {
 	}
 }
 func TestRecordFieldAccess(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "r = { name = 'value', key = 8 }\nreturn r.name"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -72,7 +72,7 @@ func TestRecordFieldAccess(t *testing.T) {
 }
 
 func TestRecordFieldAccessNumber(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "r = { name = 'value', key = 8 }\nreturn r.key"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestRecordFieldAccessNumber(t *testing.T) {
 }
 
 func TestNestedRecordsWithChainedFieldAccess(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := `admins = { alice = { name = 'Alice', age = 30 } }
 fun get_alice(r)
   return r.alice

--- a/interp/return_test.go
+++ b/interp/return_test.go
@@ -3,7 +3,7 @@ package interp
 import "testing"
 
 func TestTopLevelReturnValue(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	if err := s.Eval([]rune("return 1")); err != nil {
 		t.Fatal(err)
 	}

--- a/interp/scoping_test.go
+++ b/interp/scoping_test.go
@@ -52,7 +52,7 @@ end
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := NewState("test.vv")
 			err := s.Eval([]rune(tt.input))
 			if (err != nil) != tt.err {
 				t.Fatalf("Eval() error = %v, wantErr %v", err, tt.err)

--- a/interp/state.go
+++ b/interp/state.go
@@ -2,6 +2,8 @@ package interp
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/fj68/vvlang/ast"
 	"github.com/fj68/vvlang/parser"
@@ -9,20 +11,24 @@ import (
 )
 
 type State struct {
-	IsTestMode bool
-	Env        *Env
-	RetVals    stack.Stack[Value]
-	Defers     [][]ast.Expr
+	IsTestMode  bool
+	SourcePath  string
+	ModuleCache map[string]*VRecord
+	Env         *Env
+	RetVals     stack.Stack[Value]
+	Defers      [][]ast.Expr
 }
 
-func NewState() *State {
+func NewState(sourcePath string) *State {
 	return &State{
-		Env: NewEnv(nil),
+		SourcePath:  sourcePath,
+		ModuleCache: make(map[string]*VRecord),
+		Env:         NewEnv(nil),
 	}
 }
 
-func Eval(text []rune) error {
-	s := NewState()
+func Eval(sourcePath string, text []rune) error {
+	s := NewState(sourcePath)
 	return s.Eval(text)
 }
 
@@ -37,27 +43,19 @@ func (s *State) RegisterGlobals(values map[string]Value) {
 }
 
 func (s *State) EvalTest(text []rune) error {
-	program, err := parser.Parse(text)
+	module, err := parser.Parse(text)
 	if err != nil {
 		return err
 	}
-	return s.evalTestProgram(program)
+	return s.evalTestModule(module)
 }
 
 func (s *State) Eval(text []rune) error {
-	program, err := parser.Parse(text)
+	module, err := parser.Parse(text)
 	if err != nil {
 		return err
 	}
-	return s.evalProgram(program)
-}
-
-func (s *State) pushEnv() {
-	s.Env = NewEnv(s.Env)
-}
-
-func (s *State) popEnv() {
-	s.Env = s.Env.outer
+	return s.evalModule(module)
 }
 
 func (s *State) pushDeferScope() {
@@ -85,7 +83,7 @@ var ErrBreak = fmt.Errorf("break")
 var ErrContinue = fmt.Errorf("continue")
 var ErrReturn = fmt.Errorf("return")
 
-func (s *State) evalTestProgram(program []ast.Stmt) (err error) {
+func (s *State) evalTestModule(module *ast.Module) (err error) {
 	s.IsTestMode = true
 	s.pushDeferScope()
 	defer func() {
@@ -95,7 +93,7 @@ func (s *State) evalTestProgram(program []ast.Stmt) (err error) {
 		}
 	}()
 
-	for _, stmt := range program {
+	for _, stmt := range module.Statements {
 		if _, ok := stmt.(*ast.TestStmt); !ok {
 			// run only test stmts, and skip other top-level stmts during test evaluation
 			continue
@@ -111,7 +109,7 @@ func (s *State) evalTestProgram(program []ast.Stmt) (err error) {
 	return nil
 }
 
-func (s *State) evalProgram(program []ast.Stmt) (err error) {
+func (s *State) evalModule(module *ast.Module) (err error) {
 	s.pushDeferScope()
 	defer func() {
 		deferErr := s.popDeferScope()
@@ -120,7 +118,7 @@ func (s *State) evalProgram(program []ast.Stmt) (err error) {
 		}
 	}()
 
-	for _, stmt := range program {
+	for _, stmt := range module.Statements {
 		if err := s.evalStmt(stmt); err != nil {
 			if err == ErrReturn {
 				// Top-level return: stop program execution but do not treat as an error
@@ -171,6 +169,8 @@ func (s *State) evalStmt(stmt ast.Stmt) error {
 		return s.evalDeferStmt(v)
 	case *ast.ExternStmt:
 		return s.evalExternStmt(v)
+	case *ast.ImportStmt:
+		return s.evalImportStmt(v)
 	default:
 		return fmt.Errorf("unknown stmt: %s", v.Inspect())
 	}
@@ -234,8 +234,9 @@ func (s *State) evalAssignStmt(stmt *ast.AssignStmt) error {
 }
 
 func (s *State) evalBlockStmt(stmt *ast.BlockStmt) (err error) {
-	s.pushEnv()
-	defer s.popEnv()
+	oldEnv := s.Env
+	s.Env = NewEnv(s.Env)
+	defer func() { s.Env = oldEnv }()
 
 	s.pushDeferScope()
 	defer func() {
@@ -293,11 +294,7 @@ func (s *State) evalExpr(expr ast.Expr) (Value, error) {
 }
 
 func (s *State) evalFunLiteralExpr(expr *ast.FunLiteralExpr) (Value, error) {
-	f := &VUserFun{expr.Args, expr.Body}
-	if expr.Name != "" {
-		s.Env.Set(expr.Name, f)
-	}
-	return f, nil
+	return &VUserFun{s.Env, expr.Args, expr.Body}, nil
 }
 
 func (s *State) evalRecordLiteralExpr(expr *ast.RecordLiteralExpr) (Value, error) {
@@ -351,8 +348,9 @@ func (s *State) callUserFun(f *VUserFun, args []Value) (val Value, err error) {
 		return nil, fmt.Errorf("not enough or too much arguments")
 	}
 
-	s.pushEnv()
-	defer s.popEnv()
+	oldEnv := s.Env
+	s.Env = NewEnv(f.CapturedEnv)
+	defer func() { s.Env = oldEnv }()
 
 	s.pushDeferScope()
 	defer func() {
@@ -400,8 +398,9 @@ func (s *State) evalWhileStmt(stmt *ast.WhileStmt) error {
 	return nil
 }
 func (s *State) callBuiltinFun(f VBuiltinFun, args []Value) (Value, error) {
-	s.pushEnv()
-	defer s.popEnv()
+	oldEnv := s.Env
+	s.Env = NewEnv(s.Env)
+	defer func() { s.Env = oldEnv }()
 
 	return f(s, args)
 }
@@ -782,5 +781,74 @@ func (s *State) evalExternStmt(stmt *ast.ExternStmt) error {
 		return fmt.Errorf("extern: %s", err)
 	}
 	// success: the name is provided by the environment
+	return nil
+}
+
+func (s *State) evalImportStmt(stmt *ast.ImportStmt) error {
+	// Resolve path relative to current module's source path
+	dir := filepath.Dir(s.SourcePath)
+	targetPath := filepath.Join(dir, stmt.Path)
+	targetPath, err := filepath.Abs(targetPath)
+	if err != nil {
+		return err
+	}
+
+	// Check if already in cache (successful load or currently loading)
+	if mod, ok := s.ModuleCache[targetPath]; ok {
+		if mod == nil {
+			return fmt.Errorf("cyclic dependency detected: %s", targetPath)
+		}
+		// If we find it in the cache, it's already evaluated
+		s.Env.Set(stmt.Alias, mod)
+		return nil
+	}
+
+	// Read and parse the target file
+	text, err := os.ReadFile(targetPath)
+	if err != nil {
+		return err
+	}
+
+	module, err := parser.Parse([]rune(string(text)))
+	if err != nil {
+		return err
+	}
+
+	// Create a new state for the module
+	// Pass the same ModuleCache to detect cycles across the whole project
+	modState := NewState(targetPath)
+	modState.ModuleCache = s.ModuleCache
+
+	// To detect cycles: we can add a placeholder in the cache or check a "loading" set
+	// For simplicity, let's use the cache with a nil value as a "currently loading" marker
+	s.ModuleCache[targetPath] = nil
+	defer func() {
+		if s.ModuleCache[targetPath] == nil {
+			delete(s.ModuleCache, targetPath)
+		}
+	}()
+
+	// Evaluate the module
+	if err := modState.evalModule(module); err != nil {
+		return err
+	}
+
+	// Create a VRecord for exports
+	fields := make(map[string]Value)
+	for name := range module.Exports {
+		val, err := modState.Env.Get(name)
+		if err != nil {
+			return err
+		}
+		fields[name] = val
+	}
+	modRecord := &VRecord{Fields: fields}
+
+	// Cache the result
+	s.ModuleCache[targetPath] = modRecord
+
+	// Bind to alias in current env
+	s.Env.Set(stmt.Alias, modRecord)
+
 	return nil
 }

--- a/interp/state_test.go
+++ b/interp/state_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestState(t *testing.T) {
 	text := "fun add(a, b) return a + b end x = 1 return add(x, 0.5)"
-	if err := Eval([]rune(text)); err != nil {
+	if err := Eval("test.vv", []rune(text)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/interp/test_test.go
+++ b/interp/test_test.go
@@ -3,7 +3,7 @@ package interp
 import "testing"
 
 func TestTestBlockIsNotRun(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "let x = 1 test 'test block is not run in normal evaluation' x = 2 end return x"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -19,7 +19,7 @@ func TestTestBlockIsNotRun(t *testing.T) {
 }
 
 func TestTestBlockIsRun(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "let x = 1 test 'test block is run in test-mode evaluation' let x = 2 assert x == 2 return x end return x"
 	if err := s.EvalTest([]rune(text)); err != nil {
 		t.Fatal(err)

--- a/interp/value.go
+++ b/interp/value.go
@@ -125,8 +125,14 @@ func (v VString) LessThan(other Value) (bool, error) {
 }
 
 type VUserFun struct {
-	Args []string
-	Body []ast.Stmt
+	// CapturedEnv is the environment at the time the function was defined.
+	// This is essential for:
+	// 1. Closures: allowing functions to access variables from their outer scopes.
+	// 2. Modules: ensuring functions in imported modules can access other symbols
+	//    within that same module's top-level scope, even when called from elsewhere.
+	CapturedEnv *Env
+	Args        []string
+	Body        []ast.Stmt
 }
 
 func (v *VUserFun) Type() ValueType {

--- a/interp/while_test.go
+++ b/interp/while_test.go
@@ -3,7 +3,7 @@ package interp
 import "testing"
 
 func TestWhileLoopIncrements(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "i = 0 while i < 3 i = i + 1 end return i"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -19,7 +19,7 @@ func TestWhileLoopIncrements(t *testing.T) {
 }
 
 func TestWhileBreak(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "i = 0 while true if i == 2 break end i = i + 1 end return i"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)
@@ -35,7 +35,7 @@ func TestWhileBreak(t *testing.T) {
 }
 
 func TestWhileContinue(t *testing.T) {
-	s := NewState()
+	s := NewState("test.vv")
 	text := "i = 0 j = 0 while i < 5 i = i + 1 if i == 2 continue end j = j + 1 end return j"
 	if err := s.Eval([]rune(text)); err != nil {
 		t.Fatal(err)

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -40,6 +40,9 @@ const (
 	TNull
 	TDefer
 	TExtern
+	TPub
+	TImport
+	TFrom
 
 	// symbols
 	TLessEq
@@ -123,6 +126,12 @@ func (ty TokenType) String() string {
 		return "Defer"
 	case TExtern:
 		return "Extern"
+	case TPub:
+		return "Pub"
+	case TImport:
+		return "Import"
+	case TFrom:
+		return "From"
 
 	// symbols
 	case TLessEq:
@@ -234,6 +243,9 @@ var Keywords = map[string]TokenType{
 	"null":     TNull,
 	"defer":    TDefer,
 	"extern":   TExtern,
+	"pub":      TPub,
+	"import":   TImport,
+	"from":     TFrom,
 }
 
 var Comments = map[string]string{

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	s := interp.NewState()
+	s := interp.NewState(path)
 	s.RegisterGlobals(interp.DefaultBuiltins)
 	if err := s.Eval([]rune(string(text))); err != nil {
 		fmt.Println(err)

--- a/parser/assignment_test.go
+++ b/parser/assignment_test.go
@@ -12,12 +12,12 @@ func TestParseVarDecl(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(program) != 1 {
-		t.Fatalf("expected 1 stmt, got %d", len(program))
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(program.Statements))
 	}
-	v, ok := program[0].(*ast.VarDeclStmt)
+	v, ok := program.Statements[0].(*ast.VarDeclStmt)
 	if !ok {
-		t.Fatalf("expected VarDeclStmt, got %T", program[0])
+		t.Fatalf("expected VarDeclStmt, got %T", program.Statements[0])
 	}
 	if v.Name != "x" {
 		t.Fatalf("expected name 'x', got %s", v.Name)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -71,7 +71,7 @@ func New(text []rune) *Parser {
 	return p
 }
 
-func Parse(text []rune) ([]ast.Stmt, error) {
+func Parse(text []rune) (*ast.Module, error) {
 	p := New(text)
 	return p.Parse()
 }
@@ -106,7 +106,7 @@ func (p *Parser) registerInfixParsers() {
 	}
 }
 
-func (p *Parser) Parse() ([]ast.Stmt, error) {
+func (p *Parser) Parse() (*ast.Module, error) {
 	return p.parseProgram()
 }
 
@@ -140,7 +140,7 @@ func (p *Parser) expectNext(ty lexer.TokenType) error {
 	return nil
 }
 
-func (p *Parser) parseProgram() ([]ast.Stmt, error) {
+func (p *Parser) parseProgram() (*ast.Module, error) {
 	if err := p.readToken(); err != nil {
 		return nil, err
 	}
@@ -148,43 +148,95 @@ func (p *Parser) parseProgram() ([]ast.Stmt, error) {
 		return nil, err
 	}
 
-	var program []ast.Stmt
 	header, err := p.parseProgramHeader()
 	if err != nil {
 		return nil, err
 	}
-	program = append(program, header...)
+
+	module := &ast.Module{
+		Statements: header,
+		Exports:    make(map[string]ast.Stmt),
+	}
 
 	for {
 		if p.curToken.Type == lexer.TEOF {
 			break
 		}
+		if p.curToken.Type == lexer.TImport {
+			return nil, fmt.Errorf("import statement must be at the beginning of the program")
+		}
 		if p.curToken.Type == lexer.TExtern {
-			return nil, fmt.Errorf("extern statement must be at the beginning of the program")
+			return nil, fmt.Errorf("extern statement must be after import statements and before other statements")
 		}
 		stmts, err := p.parseToplevelStmt()
 		if err != nil {
 			return nil, err
 		}
-		program = append(program, stmts...)
+		module.Statements = append(module.Statements, stmts...)
 	}
-	return program, nil
+
+	// Collect exports
+	for _, stmt := range module.Statements {
+		switch s := stmt.(type) {
+		case *ast.VarDeclStmt:
+			if s.Exported {
+				module.Exports[s.Name] = s
+			}
+		case *ast.ExternStmt:
+			if s.Exported {
+				module.Exports[s.Name] = s
+			}
+		}
+	}
+
+	return module, nil
 }
 
 func (p *Parser) parseProgramHeader() ([]ast.Stmt, error) {
 	var header []ast.Stmt
-	for {
-		if p.curToken.Type == lexer.TExtern {
-			stmt, err := p.parseExternStmt()
-			if err != nil {
+	// imports first
+	for p.curToken.Type == lexer.TImport {
+		stmt, err := p.parseImportStmt()
+		if err != nil {
+			return nil, err
+		}
+		header = append(header, stmt)
+	}
+	// then externs
+	for p.curToken.Type == lexer.TExtern || (p.curToken.Type == lexer.TPub && p.peekToken.Type == lexer.TExtern) {
+		exported := false
+		if p.curToken.Type == lexer.TPub {
+			exported = true
+			if err := p.readToken(); err != nil {
 				return nil, err
 			}
-			header = append(header, stmt)
-			continue
 		}
-		break
+		stmt, err := p.parseExternStmt()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Exported = exported
+		header = append(header, stmt)
 	}
 	return header, nil
+}
+
+func (p *Parser) parseImportStmt() (*ast.ImportStmt, error) {
+	if err := p.expect(lexer.TImport); err != nil {
+		return nil, err
+	}
+	alias := p.curToken.Text
+	if err := p.expect(lexer.TIdent); err != nil {
+		return nil, err
+	}
+	if err := p.expect(lexer.TFrom); err != nil {
+		return nil, err
+	}
+	path := p.curToken.Text
+	if err := p.expect(lexer.TLiteral); err != nil {
+		return nil, err
+	}
+	return &ast.ImportStmt{Alias: alias, Path: path}, nil
 }
 
 func (p *Parser) parseToplevelStmt() ([]ast.Stmt, error) {
@@ -196,12 +248,37 @@ func (p *Parser) parseToplevelStmt() ([]ast.Stmt, error) {
 		return []ast.Stmt{stmt}, nil
 	}
 
+	if p.curToken.Type == lexer.TPub {
+		if err := p.readToken(); err != nil {
+			return nil, err
+		}
+		stmts, err := p.parseStmt()
+		if err != nil {
+			return nil, err
+		}
+		for _, stmt := range stmts {
+			switch s := stmt.(type) {
+			case *ast.VarDeclStmt:
+				s.Exported = true
+			default:
+				return nil, fmt.Errorf("only variable and function declarations can be exported")
+			}
+		}
+		return stmts, nil
+	}
+
 	return p.parseStmt()
 }
 
 func (p *Parser) parseStmt() ([]ast.Stmt, error) {
 	if p.curToken.Type == lexer.TEOF {
 		return nil, fmt.Errorf("unexpected EOF")
+	}
+
+	if p.curToken.Type == lexer.TFun {
+		if p.peekToken.Type == lexer.TIdent {
+			return p.parseFunDeclStmt()
+		}
 	}
 
 	if p.curToken.Type == lexer.TIdent {
@@ -344,6 +421,26 @@ func (p *Parser) parseBody() ([]ast.Stmt, error) {
 	}
 }
 
+func (p *Parser) parseFunDeclStmt() ([]ast.Stmt, error) {
+	// Named function declaration: `fun name(args) ... end`
+	// converted to `VarDeclStmt{"name", FunLiteralExpr{args, body}}`
+	if err := p.readToken(); err != nil {
+		return nil, err
+	}
+	name := p.curToken.Text
+	if err := p.readToken(); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseFunLiteralExpr()
+	if err != nil {
+		return nil, err
+	}
+	return []ast.Stmt{&ast.VarDeclStmt{
+		Name: name,
+		Body: expr,
+	}}, nil
+}
+
 func (p *Parser) parseBlockStmt() (*ast.BlockStmt, error) {
 	if err := p.expect(lexer.TBegin); err != nil {
 		return nil, err
@@ -405,8 +502,8 @@ func (p *Parser) parseExternStmt() (*ast.ExternStmt, error) {
 		if err := p.expect(lexer.TIdent); err != nil {
 			return nil, err
 		}
-		if p.curToken.Type != lexer.TLParen {
-			return nil, fmt.Errorf("expected '(', but got %s", p.curToken.Type)
+		if err := p.expect(lexer.TLParen); err != nil {
+			return nil, err
 		}
 		_, err := p.parseFunLiteralArgs()
 		if err != nil {
@@ -682,15 +779,12 @@ func (p *Parser) parseIfStmt() (*ast.IfStmt, error) {
 }
 
 func (p *Parser) parseFunLiteralExpr() (ast.Expr, error) {
-	var name string
-	if p.peekToken.Type == lexer.TIdent {
+	if p.curToken.Type == lexer.TFun {
 		if err := p.readToken(); err != nil {
 			return nil, err
 		}
-		name = p.curToken.Text
 	}
-
-	if err := p.expectNext(lexer.TLParen); err != nil {
+	if err := p.expect(lexer.TLParen); err != nil {
 		return nil, err
 	}
 
@@ -709,7 +803,6 @@ func (p *Parser) parseFunLiteralExpr() (ast.Expr, error) {
 	}
 
 	return &ast.FunLiteralExpr{
-		Name: name,
 		Args: args,
 		Body: body,
 	}, nil
@@ -718,28 +811,22 @@ func (p *Parser) parseFunLiteralExpr() (ast.Expr, error) {
 func (p *Parser) parseFunLiteralArgs() ([]string, error) {
 	var args []string
 	for {
-		if p.peekToken.Type == lexer.TEOF {
-			return nil, fmt.Errorf("unexpected eof while reading function arguments")
-		}
-		if p.peekToken.Type == lexer.TRParen {
+		if p.curToken.Type == lexer.TRParen {
 			break
 		}
-		if err := p.expectNext(lexer.TIdent); err != nil {
+		name := p.curToken.Text
+		if err := p.expect(lexer.TIdent); err != nil {
 			return nil, err
 		}
-		args = append(args, p.curToken.Text)
-		if p.peekToken.Type == lexer.TRParen {
+		args = append(args, name)
+		if p.curToken.Type == lexer.TRParen {
 			break
 		}
-		if err := p.expectNext(lexer.TComma); err != nil {
+		if err := p.expect(lexer.TComma); err != nil {
 			return nil, err
 		}
 	}
-	// read remaining TRParen
-	if err := p.readToken(); err != nil {
-		return nil, err
-	}
-	if err := p.readToken(); err != nil {
+	if err := p.expect(lexer.TRParen); err != nil {
 		return nil, err
 	}
 	return args, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,9 +1,10 @@
 package parser
 
 import (
-	"github.com/fj68/vvlang/ast"
 	"strings"
 	"testing"
+
+	"github.com/fj68/vvlang/ast"
 )
 
 func TestParser(t *testing.T) {
@@ -14,7 +15,7 @@ func TestParser(t *testing.T) {
 		return
 	}
 	var b strings.Builder
-	for _, stmt := range program {
+	for _, stmt := range program.Statements {
 		b.WriteString(stmt.Inspect())
 	}
 	s := b.String()
@@ -28,7 +29,7 @@ func TestParse(t *testing.T) {
 		t.Fatal(err)
 	}
 	var b strings.Builder
-	for _, stmt := range v {
+	for _, stmt := range v.Statements {
 		b.WriteString(stmt.Inspect())
 	}
 	s := b.String()
@@ -41,10 +42,10 @@ func TestParseWhile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(v) != 1 {
-		t.Fatalf("expected 1 stmt, got %d", len(v))
+	if len(v.Statements) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(v.Statements))
 	}
-	if _, ok := v[0].(*ast.WhileStmt); !ok {
-		t.Fatalf("expected WhileStmt, got %T", v[0])
+	if _, ok := v.Statements[0].(*ast.WhileStmt); !ok {
+		t.Fatalf("expected WhileStmt, got %T", v.Statements[0])
 	}
 }

--- a/parser/record_test.go
+++ b/parser/record_test.go
@@ -1,8 +1,9 @@
 package parser
 
 import (
-	"github.com/fj68/vvlang/ast"
 	"testing"
+
+	"github.com/fj68/vvlang/ast"
 )
 
 func TestParseRecordLiteral(t *testing.T) {
@@ -11,12 +12,12 @@ func TestParseRecordLiteral(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(v) != 1 {
-		t.Fatalf("expected 1 stmt, got %d", len(v))
+	if len(v.Statements) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(v.Statements))
 	}
-	exprStmt, ok := v[0].(*ast.ExprStmt)
+	exprStmt, ok := v.Statements[0].(*ast.ExprStmt)
 	if !ok {
-		t.Fatalf("expected ExprStmt, got %T", v[0])
+		t.Fatalf("expected ExprStmt, got %T", v.Statements[0])
 	}
 	rec, ok := exprStmt.Expr.(*ast.RecordLiteralExpr)
 	if !ok {
@@ -39,12 +40,12 @@ func TestParseRecordLiteralTrailingComma(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(v) != 1 {
-		t.Fatalf("expected 1 stmt, got %d", len(v))
+	if len(v.Statements) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(v.Statements))
 	}
-	exprStmt, ok := v[0].(*ast.ExprStmt)
+	exprStmt, ok := v.Statements[0].(*ast.ExprStmt)
 	if !ok {
-		t.Fatalf("expected ExprStmt, got %T", v[0])
+		t.Fatalf("expected ExprStmt, got %T", v.Statements[0])
 	}
 	rec, ok := exprStmt.Expr.(*ast.RecordLiteralExpr)
 	if !ok {

--- a/parser/return_test.go
+++ b/parser/return_test.go
@@ -12,11 +12,11 @@ func TestParseReturnTopLevel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(program) != 1 {
-		t.Fatalf("expected 1 stmt, got %d", len(program))
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(program.Statements))
 	}
-	if _, ok := program[0].(*ast.ReturnStmt); !ok {
-		t.Fatalf("expected ReturnStmt, got %T", program[0])
+	if _, ok := program.Statements[0].(*ast.ReturnStmt); !ok {
+		t.Fatalf("expected ReturnStmt, got %T", program.Statements[0])
 	}
 }
 
@@ -26,12 +26,12 @@ func TestParseReturnNoValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(program) != 1 {
-		t.Fatalf("expected 1 stmt, got %d", len(program))
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(program.Statements))
 	}
-	rtn, ok := program[0].(*ast.ReturnStmt)
+	rtn, ok := program.Statements[0].(*ast.ReturnStmt)
 	if !ok {
-		t.Fatalf("expected ReturnStmt, got %T", program[0])
+		t.Fatalf("expected ReturnStmt, got %T", program.Statements[0])
 	}
 	if rtn.Value != nil {
 		t.Fatalf("expected nil value, got %v", rtn.Value)


### PR DESCRIPTION
## Description
This PR implements a basic module system for `vvlang`, supporting exported symbols and relative file imports.

### Key Features
- **`pub` keyword**: Prefix for variable and function declarations to enable exports.
- **`import` statement**: `import <alias> from './path.vv'` syntax for importing local modules.
- **Module Caching**: Global cache to avoid redundant evaluation and ensure consistent state.
- **Cyclic Dependency Detection**: Detects and reports circular imports.
- **Environment Capture**: `VUserFun` now captures its definition-time environment, enabling support for closures and module-level scoping.
- **Header Enforcement**: Strict ordering in file headers: `import` -> `extern` -> other statements.
### Changes
- **Parser**: Refactored `parseProgram` and `parseStmt`. Extracted `parseFunDeclStmt`. Enforced header ordering.
- **Interpreter**: Added `SourcePath` and `ModuleCache` to `State`. Implemented `evalImportStmt`.
- **AST**: Added `Module` and `ImportStmt` nodes. Added `Exported` flag to declarations.
- **Lexer**: Added `pub`, `import`, and `from` keywords.
## Verification
- **Unit Tests**: All existing tests updated and passing.
- **New Tests**: Added `interp/module_test.go` covering:
    - Basic cross-file imports and function calls.
    - Exported vs. non-exported visibility.
    - Nested imports.
    - Cyclic dependency detection.
## How to Test
1. Create `math.vv` with `pub fun add(a, b) return a + b end`.
2. Create `main.vv` with `import m from './math.vv'; return m.add(1, 2)`.
3. Run `go run main.go main.vv`.