### PR TITLE
Implement docstrings and sys.help() module

### DIFF
--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -64,9 +64,10 @@ func (stmt *VarAssignStmt) Inspect() string {
 }
 
 type VarDeclStmt struct {
-	Name     string
-	Body     Expr
-	Exported bool
+	Name      string
+	Body      Expr
+	Exported  bool
+	Docstring map[string]string
 }
 
 func (stmt *VarDeclStmt) Inspect() string {
@@ -153,6 +154,7 @@ func (stmt *ImportStmt) Inspect() string {
 type Module struct {
 	Statements []Stmt
 	Exports    map[string]Stmt
+	Docstring  map[string]string
 }
 
 func (m *Module) Inspect() string {

--- a/interp/builtins.go
+++ b/interp/builtins.go
@@ -3,6 +3,8 @@ package interp
 import (
 	"fmt"
 	"math"
+	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -18,6 +20,7 @@ var DefaultBuiltins = map[string]Value{
 	"string": VBuiltinFun(builtinString),
 	"len":    VBuiltinFun(builtinLen),
 	"push":   VBuiltinFun(builtinPush),
+	"help":   VBuiltinFun(builtinHelp),
 }
 
 func builtinNot(s *State, args []Value) (Value, error) {
@@ -177,5 +180,74 @@ func builtinPush(s *State, args []Value) (Value, error) {
 		return nil, fmt.Errorf("argument for push() is expected list, but got %s", args[0].Type().String())
 	}
 	list.Elements = append(list.Elements, args[1])
+	return nil, nil
+}
+
+// helpLang resolves the two-letter language code from $LANG (e.g. "ja_JP.UTF-8" -> "ja").
+func helpLang() string {
+	lang := os.Getenv("LANG")
+	if lang == "" || lang == "C" || lang == "POSIX" {
+		return "en"
+	}
+	code := strings.Split(lang, "_")[0]
+	code = strings.Split(code, ".")[0]
+	if code == "" {
+		return "en"
+	}
+	return code
+}
+
+// pickDoc selects the appropriate language entry, falling back to "en" if not found.
+func pickDoc(docs map[string]string) string {
+	if docs == nil {
+		return ""
+	}
+	lang := helpLang()
+	if v, ok := docs[lang]; ok {
+		return v
+	}
+	return docs["en"]
+}
+
+func builtinHelp(s *State, args []Value) (Value, error) {
+	if len(args) == 0 {
+		// Print all top-level env names
+		names := make([]string, 0)
+		for k := range s.Env.Values {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		fmt.Println(strings.Join(names, "\n"))
+		return nil, nil
+	}
+	if len(args) != 1 {
+		return nil, fmt.Errorf("help() takes 0 or 1 argument")
+	}
+
+	switch v := args[0].(type) {
+	case *VModule:
+		// Print module docstring
+		moduleDoc := pickDoc(v.Docstring)
+		if moduleDoc != "" {
+			fmt.Println(moduleDoc)
+		}
+		// Print one-liner per exported field
+		keys := make([]string, 0, len(v.Fields))
+		for k := range v.Fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fieldDoc := pickDoc(v.FieldDocstrings[k])
+			// Show only first line of field docstring as one-liner
+			oneLiner := ""
+			if fieldDoc != "" {
+				oneLiner = " - " + strings.SplitN(fieldDoc, "\n", 2)[0]
+			}
+			fmt.Printf("- %s%s\n", k, oneLiner)
+		}
+	default:
+		fmt.Printf("type: %s\n", args[0].Type())
+	}
 	return nil, nil
 }

--- a/interp/state.go
+++ b/interp/state.go
@@ -14,7 +14,7 @@ import (
 type State struct {
 	IsTestMode  bool
 	SourcePath  string
-	ModuleCache map[string]*VRecord
+	ModuleCache map[string]*VModule
 	Env         *Env
 	RetVals     stack.Stack[Value]
 	Defers      [][]ast.Expr
@@ -24,7 +24,7 @@ type State struct {
 func NewState(sourcePath string) *State {
 	return &State{
 		SourcePath:  sourcePath,
-		ModuleCache: make(map[string]*VRecord),
+		ModuleCache: make(map[string]*VModule),
 		Env:         NewEnv(nil),
 		NewState:    NewState,
 	}
@@ -763,8 +763,13 @@ func (s *State) evalFieldAccessExpr(expr *ast.FieldAccessExpr) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	record, ok := recordVal.(*VRecord)
-	if !ok {
+	var record *VRecord
+	switch tv := recordVal.(type) {
+	case *VRecord:
+		record = tv
+	case *VModule:
+		record = tv.VRecord
+	default:
 		return nil, fmt.Errorf("expected record for field access, but got %s", recordVal.Type())
 	}
 	fieldName := string(expr.Field)
@@ -860,7 +865,7 @@ func (s *State) evalImportStmt(stmt *ast.ImportStmt) error {
 		return err
 	}
 
-	// Create a VRecord for exports
+	// Create a VModule for exports, carrying docstring metadata
 	fields := make(map[string]Value)
 	for name := range module.Exports {
 		val, err := modState.Env.Get(name)
@@ -869,7 +874,19 @@ func (s *State) evalImportStmt(stmt *ast.ImportStmt) error {
 		}
 		fields[name] = val
 	}
-	modRecord := &VRecord{Fields: fields}
+
+	fieldDocstrings := make(map[string]map[string]string)
+	for _, stmt := range module.Statements {
+		if vd, ok := stmt.(*ast.VarDeclStmt); ok && vd.Exported && vd.Docstring != nil {
+			fieldDocstrings[vd.Name] = vd.Docstring
+		}
+	}
+
+	modRecord := &VModule{
+		VRecord:         &VRecord{Fields: fields},
+		Docstring:       module.Docstring,
+		FieldDocstrings: fieldDocstrings,
+	}
 
 	// Cache the result
 	s.ModuleCache[targetPath] = modRecord

--- a/interp/value.go
+++ b/interp/value.go
@@ -231,8 +231,13 @@ func (v *VRecord) String() string {
 }
 
 func (v *VRecord) Equal(other Value) (bool, error) {
-	o, ok := other.(*VRecord)
-	if !ok {
+	var o *VRecord
+	switch tv := other.(type) {
+	case *VRecord:
+		o = tv
+	case *VModule:
+		o = tv.VRecord
+	default:
 		return false, fmt.Errorf("expected record, but got %s", other.Type())
 	}
 	if len(o.Fields) != len(v.Fields) {
@@ -256,6 +261,25 @@ func (v *VRecord) Equal(other Value) (bool, error) {
 
 func (v *VRecord) LessThan(other Value) (bool, error) {
 	return false, fmt.Errorf("unable to compare records")
+}
+
+// VModule wraps a VRecord with docstring metadata. It represents an imported module.
+type VModule struct {
+	*VRecord
+	Docstring       map[string]string
+	FieldDocstrings map[string]map[string]string
+}
+
+func (v *VModule) Type() ValueType {
+	return VTRecord // still reported as record for type() calls
+}
+
+func (v *VModule) Equal(other Value) (bool, error) {
+	return Value(v) == other, nil
+}
+
+func (v *VModule) LessThan(other Value) (bool, error) {
+	return false, fmt.Errorf("unable to compare modules")
 }
 
 type VNull struct{}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -20,6 +20,11 @@ func (lex *Lexer) Next() (*Token, error) {
 		return lex.newToken(TEOF), nil
 	}
 
+	// Check for docstring before anything else
+	if lex.s.Peek(3) == "///" {
+		return lex.docstring()
+	}
+
 	r := lex.s.Current()
 
 	for sym2, ty := range Symbols2 {
@@ -84,12 +89,33 @@ func (lex *Lexer) skipWhitespaces() int {
 }
 
 func (lex *Lexer) skipComment() int {
+	// Check docstring marker first to avoid treating it as a regular comment
+	if lex.s.Peek(3) == "///" {
+		return 0 // Do not skip; Next() will emit TDocstring
+	}
 	for start, end := range Comments {
 		if lex.s.Peek(len(start)) == start {
 			return lex.comment(start, end)
 		}
 	}
 	return 0
+}
+
+// docstring reads a `///` line and emits a TDocstring token with the trimmed content.
+func (lex *Lexer) docstring() (*Token, error) {
+	lex.s.Skip(3) // skip `///`
+	// skip optional single space after ///
+	if !lex.s.IsEOF() && lex.s.Current() == ' ' {
+		lex.s.Skip(1)
+	}
+	// Read until end of line
+	for !lex.s.IsEOF() && lex.s.Current() != '\n' {
+		lex.s.Advance(1)
+	}
+	if !lex.s.IsEOF() {
+		lex.s.Skip(1) // skip the newline
+	}
+	return lex.newToken(TDocstring), nil
 }
 
 func (lex *Lexer) comment(start, end string) int {

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -16,6 +16,7 @@ const (
 	TLiteral
 	TInterpolated
 	TComment
+	TDocstring
 
 	// keywords
 	TFun
@@ -80,6 +81,8 @@ func (ty TokenType) String() string {
 		return "Interpolated"
 	case TComment:
 		return "Comment"
+	case TDocstring:
+		return "Docstring"
 
 		// keywords
 	case TFun:

--- a/lib/std/sys.vv
+++ b/lib/std/sys.vv
@@ -1,0 +1,1 @@
+pub extern 'native' fun help(x)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/fj68/vvlang/ast"
 	"github.com/fj68/vvlang/lexer"
@@ -140,6 +141,34 @@ func (p *Parser) expectNext(ty lexer.TokenType) error {
 	return nil
 }
 
+func (p *Parser) parseDocstring() map[string]string {
+	docs := make(map[string]string)
+	lang := "en"
+	for p.curToken.Type == lexer.TDocstring {
+		line := p.curToken.Text
+		if len(line) >= 6 && line[:6] == "@lang " {
+			lang = line[6:]
+			// Consume the @lang token and move on
+			if err := p.readToken(); err != nil {
+				break
+			}
+			continue
+		}
+		docs[lang] += line + "\n"
+		if err := p.readToken(); err != nil {
+			break
+		}
+	}
+	// Trim trailing newlines from each lang entry
+	for k, v := range docs {
+		docs[k] = strings.TrimRight(v, "\n")
+	}
+	if len(docs) == 0 {
+		return nil
+	}
+	return docs
+}
+
 func (p *Parser) parseProgram() (*ast.Module, error) {
 	if err := p.readToken(); err != nil {
 		return nil, err
@@ -147,6 +176,9 @@ func (p *Parser) parseProgram() (*ast.Module, error) {
 	if err := p.readToken(); err != nil {
 		return nil, err
 	}
+
+	// Collect module-level docstring (appears before imports / first statement)
+	moduleDocstring := p.parseDocstring()
 
 	header, err := p.parseProgramHeader()
 	if err != nil {
@@ -156,6 +188,7 @@ func (p *Parser) parseProgram() (*ast.Module, error) {
 	module := &ast.Module{
 		Statements: header,
 		Exports:    make(map[string]ast.Stmt),
+		Docstring:  moduleDocstring,
 	}
 
 	for {
@@ -240,6 +273,9 @@ func (p *Parser) parseImportStmt() (*ast.ImportStmt, error) {
 }
 
 func (p *Parser) parseToplevelStmt() ([]ast.Stmt, error) {
+	// Consume docstring preceding the declaration
+	docstring := p.parseDocstring()
+
 	if p.curToken.Type == lexer.TTest {
 		stmt, err := p.parseTestStmt()
 		if err != nil {
@@ -260,6 +296,7 @@ func (p *Parser) parseToplevelStmt() ([]ast.Stmt, error) {
 			switch s := stmt.(type) {
 			case *ast.VarDeclStmt:
 				s.Exported = true
+				s.Docstring = docstring
 			default:
 				return nil, fmt.Errorf("only variable and function declarations can be exported")
 			}


### PR DESCRIPTION
Adds support for `///` docstrings on `pub let`, `pub fun`, and module declarations.
Docstrings support i18n via the `@lang` directive.
The new `sys` module in the standard library provides `sys.help(value)` to display these descriptions based on the current language (resolving from `$LANG`).

Key changes:
- Lexer: detects `///` as `TDocstring` tokens.
- AST: `Docstring` map added to `VarDeclStmt` and `Module`.
- Parser: `parseDocstring` helper accumulates descriptions and `@lang` directives.
- Interpreter: `VModule` value type introduced to wrap module exports with docstring metadata.
- Stdlib: `lib/std/sys.vv` added with native `help()` implementation.

Closes #17