### PR TITLE
Native Registration Refactor

### DIFF
--- a/interp/extern_test.go
+++ b/interp/extern_test.go
@@ -59,11 +59,29 @@ func TestExtern(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewState("test.vv")
-			s.RegisterGlobals(tt.globals)
+			s.RegisterNatives(tt.globals)
 			err := s.Eval([]rune(tt.input))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Eval() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
+
+	t.Run("extern native exported", func(t *testing.T) {
+		s := NewState("test.vv")
+		s.RegisterNative("f", VBuiltinFun(func(s *State, args []Value) (Value, error) {
+			return VNumber(42), nil
+		}))
+		err := s.Eval([]rune("pub extern 'native' fun f()"))
+		if err != nil {
+			t.Fatalf("Eval() error = %v", err)
+		}
+		val, err := s.Env.Get("f")
+		if err != nil {
+			t.Fatalf("Env.Get(\"f\") error = %v", err)
+		}
+		if _, ok := val.(VBuiltinFun); !ok {
+			t.Errorf("expected VBuiltinFun, but got %T", val)
+		}
+	})
 }

--- a/interp/state.go
+++ b/interp/state.go
@@ -12,21 +12,23 @@ import (
 )
 
 type State struct {
-	IsTestMode  bool
-	SourcePath  string
-	ModuleCache map[string]*VModule
-	Env         *Env
-	RetVals     stack.Stack[Value]
-	Defers      [][]ast.Expr
-	NewState    func(sourcePath string) *State
+	IsTestMode   bool
+	SourcePath   string
+	ModuleCache  map[string]*VModule
+	Env          *Env
+	RetVals      stack.Stack[Value]
+	Defers       [][]ast.Expr
+	NativeValues map[string]Value
+	NewState     func(sourcePath string) *State
 }
 
 func NewState(sourcePath string) *State {
 	return &State{
-		SourcePath:  sourcePath,
-		ModuleCache: make(map[string]*VModule),
-		Env:         NewEnv(nil),
-		NewState:    NewState,
+		SourcePath:   sourcePath,
+		ModuleCache:  make(map[string]*VModule),
+		Env:          NewEnv(nil),
+		NativeValues: make(map[string]Value),
+		NewState:     NewState,
 	}
 }
 
@@ -65,6 +67,15 @@ func (s *State) RegisterGlobal(name string, value Value) {
 func (s *State) RegisterGlobals(values map[string]Value) {
 	for name, value := range values {
 		s.RegisterGlobal(name, value)
+	}
+}
+func (s *State) RegisterNative(name string, value Value) {
+	s.NativeValues[name] = value
+}
+
+func (s *State) RegisterNatives(values map[string]Value) {
+	for name, value := range values {
+		s.RegisterNative(name, value)
 	}
 }
 
@@ -846,11 +857,25 @@ func (s *State) evalDeferStmt(stmt *ast.DeferStmt) error {
 	return nil
 }
 func (s *State) evalExternStmt(stmt *ast.ExternStmt) error {
-	_, err := s.Env.Get(stmt.Name)
-	if err != nil {
-		return fmt.Errorf("extern: %s", err)
+	if stmt.Type != "native" {
+		return fmt.Errorf("extern: unsupported type %s", stmt.Type)
 	}
-	// success: the name is provided by the environment
+
+	val, ok := s.NativeValues[stmt.Name]
+	if !ok {
+		return fmt.Errorf("extern native: %s not registered", stmt.Name)
+	}
+
+	s.Env.Set(stmt.Name, val)
+
+	if stmt.Exported {
+		// Mark as exported in the environment if the environment supports it,
+		// or handle it during module export collection.
+		// Currently VModule collection looks at the environment for names in module.Exports.
+		// So we just need to make sure the name is in module.Exports, but that's already
+		// handled by the parser (it populates module.Exports).
+		// However, we need to ensure the value is present in s.Env.
+	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 		// Register module-specific built-ins
 		for stdPath, funcs := range moduleBuiltins {
 			if sourcePath == mod.GetPackagePath(stdPath) {
-				ns.RegisterGlobals(funcs)
+				ns.RegisterNatives(funcs)
 				break
 			}
 		}


### PR DESCRIPTION
# Native Registration Refactor

I have refactored the native registration system in `vvlang` to ensure a cleaner separation between language builtins and user-provided native functions.

## Changes Made

### interp.State
- Added `NativeValues map[string]Value` to the `State` struct as a dedicated registry for native functions and variables.
- Added `RegisterNative` and `RegisterNatives` methods.
- Updated `NewState` to initialize the `NativeValues` map.

### extern Statement Logic
- Refactored `evalExternStmt` in `interp/state.go`.
- It now specifically looks up the requested name in `s.NativeValues` if the type is `'native'`.
- If found, it binds the value to the current environment (`s.Env.Set`).
- Supports the `pub` keyword for exporting native values.

### main.go
- Updated the built-in registration logic to use `RegisterNatives`.

## Verification Results
- All tests in `interp/extern_test.go` passed, including a new test case for exported native functions.
- Full test suite passed.