### PR TITLE
Implement String Interpolation and `str` Syntax

### DIFF
--- a/ast/expr.go
+++ b/ast/expr.go
@@ -217,3 +217,12 @@ type NotExpr struct {
 func (expr *NotExpr) Inspect() string {
 	return fmt.Sprintf("NotExpr{%s}", expr.Value.Inspect())
 }
+
+type StrExpr struct {
+	Position
+	Value Expr
+}
+
+func (expr *StrExpr) Inspect() string {
+	return fmt.Sprintf("StrExpr{%s}", expr.Value.Inspect())
+}

--- a/interp/interpolation_test.go
+++ b/interp/interpolation_test.go
@@ -1,0 +1,38 @@
+package interp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInterpolation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`let name = "world"; return "hello, {name}!"`, `"hello, world!"`},
+		{`let a = 1; let b = 2; return "{a} + {b} = {a + b}"`, `"1 + 2 = 3"`},
+		{`let l = [1, 2]; return "list: {l}"`, `"list: [1, 2]"`},
+		{`let r = { a = 1, b = "s" }; return "record: {r}"`, `"record: { a = 1, b = s }"`},
+		{`let f = fun() end; return "fun: {f}"`, `"fun: <function>"`},
+		{`return "nested: {{1}} {2}"`, `"nested: {1} 2"`},
+	}
+
+	for _, tt := range tests {
+		s := NewState("test.vv")
+		// replace ; with \n for test convenience
+		input := strings.ReplaceAll(tt.input, ";", "\n")
+		err := s.Eval([]rune(input))
+		if err != nil {
+			t.Fatalf("eval failed for input %q: %v", tt.input, err)
+		}
+		if s.RetVals.Len() == 0 {
+			t.Errorf("input %q: expected a return value on RetVals, but got none", tt.input)
+			continue
+		}
+		got := s.RetVals.Pop().String()
+		if got != tt.expected {
+			t.Errorf("input %q: expected %s, got %s", tt.input, tt.expected, got)
+		}
+	}
+}

--- a/interp/state.go
+++ b/interp/state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/fj68/vvlang/ast"
 	"github.com/fj68/vvlang/mod"
@@ -332,6 +333,10 @@ func (s *State) evalExpr(expr ast.Expr) (Value, error) {
 		return s.evalTypeExpr(v)
 	case *ast.NotExpr:
 		return s.evalNotExpr(v)
+	case *ast.StrExpr:
+		return s.evalStrExpr(v)
+	case *ast.InterpolatedStringLiteralExpr:
+		return s.evalInterpolatedStringLiteralExpr(v)
 	default:
 		return nil, fmt.Errorf("unknown expr: %s", v.Inspect())
 	}
@@ -366,6 +371,28 @@ func (s *State) evalNotExpr(expr *ast.NotExpr) (Value, error) {
 		return nil, fmt.Errorf("argument for not() is expected bool, but got %s", v.Type())
 	}
 	return VBool(!bool(b)), nil
+}
+
+func (s *State) evalStrExpr(expr *ast.StrExpr) (Value, error) {
+	v, err := s.evalExpr(expr.Value)
+	if err != nil {
+		return nil, err
+	}
+	return VString(v.Str()), nil
+}
+
+func (s *State) evalInterpolatedStringLiteralExpr(expr *ast.InterpolatedStringLiteralExpr) (Value, error) {
+	var b strings.Builder
+	b.WriteString(expr.Texts[0])
+	for i, valueExpr := range expr.Values {
+		v, err := s.evalExpr(valueExpr)
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(v.Str())
+		b.WriteString(expr.Texts[i+1])
+	}
+	return VString(b.String()), nil
 }
 
 func (s *State) evalFunLiteralExpr(expr *ast.FunLiteralExpr) (Value, error) {
@@ -931,7 +958,7 @@ func (s *State) evalImportStmt(stmt *ast.ImportStmt) error {
 	// Pass the same ModuleCache to detect cycles across the whole project
 	modState := s.NewState(targetPath)
 	modState.ModuleCache = s.ModuleCache
-	modState.IsTestMode = s.IsTestMode // propagate test mode to imported modules
+	modState.IsTestMode = s.IsTestMode         // propagate test mode to imported modules
 	modState.BuiltinModules = s.BuiltinModules // propagate builtin modules to imported modules
 
 	// To detect cycles: we can add a placeholder in the cache or check a "loading" set

--- a/interp/str_test.go
+++ b/interp/str_test.go
@@ -1,0 +1,31 @@
+package interp
+
+import (
+	"testing"
+)
+
+func TestStrSyntax(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`return str(123)`, `"123"`},
+		{`return str(true)`, `"true"`},
+		{`return str([1, 2])`, `"[1, 2]"`},
+		{`return str({a=1})`, `"{ a = 1 }"`},
+		{`return str(null)`, `"null"`},
+		{"let x = 8\n return str(x)", `"8"`},
+	}
+
+	for _, tt := range tests {
+		s := NewState("test.vv")
+		err := s.Eval([]rune(tt.input))
+		if err != nil {
+			t.Fatalf("eval failed for input %q: %v", tt.input, err)
+		}
+		got := s.RetVals.Pop().String()
+		if got != tt.expected {
+			t.Errorf("input %q: expected %s, got %s", tt.input, tt.expected, got)
+		}
+	}
+}

--- a/interp/value.go
+++ b/interp/value.go
@@ -46,6 +46,7 @@ func (ty ValueType) String() string {
 type Value interface {
 	Type() ValueType
 	String() string
+	Str() string
 	Equal(Value) (bool, error)
 	LessThan(Value) (bool, error)
 }
@@ -58,6 +59,10 @@ func (v VBool) Type() ValueType {
 
 func (v VBool) String() string {
 	return fmt.Sprintf("%t", bool(v))
+}
+
+func (v VBool) Str() string {
+	return v.String()
 }
 
 func (v VBool) Equal(other Value) (bool, error) {
@@ -80,6 +85,10 @@ func (v VNumber) Type() ValueType {
 
 func (v VNumber) String() string {
 	return fmt.Sprintf("%g", float64(v))
+}
+
+func (v VNumber) Str() string {
+	return v.String()
 }
 
 func (v VNumber) Equal(other Value) (bool, error) {
@@ -106,6 +115,10 @@ func (v VString) Type() ValueType {
 
 func (v VString) String() string {
 	return fmt.Sprintf("\"%s\"", string(v))
+}
+
+func (v VString) Str() string {
+	return string(v)
 }
 
 func (v VString) Equal(other Value) (bool, error) {
@@ -140,7 +153,11 @@ func (v *VUserFun) Type() ValueType {
 }
 
 func (v *VUserFun) String() string {
-	return "fun"
+	return "<function>"
+}
+
+func (v *VUserFun) Str() string {
+	return v.String()
 }
 
 func (v *VUserFun) Equal(other Value) (bool, error) {
@@ -158,7 +175,11 @@ func (v VBuiltinFun) Type() ValueType {
 }
 
 func (v VBuiltinFun) String() string {
-	return "fun"
+	return "<function>"
+}
+
+func (v VBuiltinFun) Str() string {
+	return v.String()
 }
 
 func (v VBuiltinFun) Equal(other Value) (bool, error) {
@@ -180,9 +201,13 @@ func (v *VList) Type() ValueType {
 func (v *VList) String() string {
 	var elements []string
 	for _, elem := range v.Elements {
-		elements = append(elements, elem.String())
+		elements = append(elements, elem.Str())
 	}
 	return fmt.Sprintf("[%s]", strings.Join(elements, ", "))
+}
+
+func (v *VList) Str() string {
+	return v.String()
 }
 
 func (v *VList) Equal(other Value) (bool, error) {
@@ -225,9 +250,13 @@ func (v *VRecord) String() string {
 	sort.Strings(keys)
 	var parts []string
 	for _, k := range keys {
-		parts = append(parts, fmt.Sprintf("%s = %s", k, v.Fields[k].String()))
+		parts = append(parts, fmt.Sprintf("%s = %s", k, v.Fields[k].Str()))
 	}
-	return fmt.Sprintf("{%s}", strings.Join(parts, ", "))
+	return fmt.Sprintf("{ %s }", strings.Join(parts, ", "))
+}
+
+func (v *VRecord) Str() string {
+	return v.String()
 }
 
 func (v *VRecord) Equal(other Value) (bool, error) {
@@ -282,6 +311,10 @@ func (v *VModule) LessThan(other Value) (bool, error) {
 	return false, fmt.Errorf("unable to compare modules")
 }
 
+func (v *VModule) Str() string {
+	return v.VRecord.Str()
+}
+
 type VNull struct{}
 
 func (v VNull) Type() ValueType {
@@ -290,6 +323,10 @@ func (v VNull) Type() ValueType {
 
 func (v VNull) String() string {
 	return "null"
+}
+
+func (v VNull) Str() string {
+	return v.String()
 }
 
 func (v VNull) Equal(other Value) (bool, error) {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -180,7 +180,7 @@ func (lex *Lexer) interpolated() (*Token, error) {
 
 	lex.s.Skip(1) // skip end marker
 
-	return lex.newToken(TLiteral), nil
+	return lex.newToken(TInterpolated), nil
 }
 
 func (lex *Lexer) scanEscapeSequence() {

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -46,6 +46,7 @@ const (
 	TFrom
 	TType
 	TNot
+	TStr
 
 	// symbols
 	TLessEq
@@ -141,6 +142,8 @@ func (ty TokenType) String() string {
 		return "Type"
 	case TNot:
 		return "Not"
+	case TStr:
+		return "Str"
 
 	// symbols
 	case TLessEq:
@@ -257,6 +260,7 @@ var Keywords = map[string]TokenType{
 	"from":     TFrom,
 	"type":     TType,
 	"not":      TNot,
+	"str":      TStr,
 }
 
 var Comments = map[string]string{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -79,18 +79,20 @@ func Parse(text []rune) (*ast.Module, error) {
 
 func (p *Parser) registerPrefixParsers() {
 	p.prefixParsers = map[lexer.TokenType]PrefixParser{
-		lexer.TDigit:    p.parseDigitLiteralExpr,
-		lexer.TTrue:     p.parseBoolLiteralExpr,
-		lexer.TFalse:    p.parseBoolLiteralExpr,
-		lexer.TLiteral:  p.parseStringLiteralExpr,
-		lexer.THyphen:   p.parsePrefixExpr,
-		lexer.TIdent:    p.parseVarRefExpr,
-		lexer.TFun:      p.parseFunLiteralExpr,
-		lexer.TLBrace:   p.parseListLiteralExpr,
-		lexer.TLBracket: p.parseRecordLiteralExpr,
-		lexer.TNull:     p.parseNullLiteralExpr,
-		lexer.TType:     p.parseTypeExpr,
-		lexer.TNot:      p.parseNotExpr,
+		lexer.TDigit:        p.parseDigitLiteralExpr,
+		lexer.TTrue:         p.parseBoolLiteralExpr,
+		lexer.TFalse:        p.parseBoolLiteralExpr,
+		lexer.TLiteral:      p.parseStringLiteralExpr,
+		lexer.THyphen:       p.parsePrefixExpr,
+		lexer.TIdent:        p.parseVarRefExpr,
+		lexer.TFun:          p.parseFunLiteralExpr,
+		lexer.TLBrace:       p.parseListLiteralExpr,
+		lexer.TLBracket:     p.parseRecordLiteralExpr,
+		lexer.TNull:         p.parseNullLiteralExpr,
+		lexer.TType:         p.parseTypeExpr,
+		lexer.TNot:          p.parseNotExpr,
+		lexer.TStr:          p.parseStrExpr,
+		lexer.TInterpolated: p.parseInterpolatedStringLiteralExpr,
 	}
 }
 
@@ -126,6 +128,16 @@ func (p *Parser) readToken() error {
 func (p *Parser) expect(ty lexer.TokenType) error {
 	if p.curToken.Type != ty {
 		return fmt.Errorf("expected %s, but got %s", ty, p.curToken.Type)
+	}
+	if err := p.readToken(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Parser) expectString() error {
+	if p.curToken.Type != lexer.TLiteral && p.curToken.Type != lexer.TInterpolated {
+		return fmt.Errorf("expected string literal, but got %s", p.curToken.Type)
 	}
 	if err := p.readToken(); err != nil {
 		return err
@@ -268,7 +280,7 @@ func (p *Parser) parseImportStmt() (*ast.ImportStmt, error) {
 		return nil, err
 	}
 	path := p.curToken.Text
-	if err := p.expect(lexer.TLiteral); err != nil {
+	if err := p.expectString(); err != nil {
 		return nil, err
 	}
 	return &ast.ImportStmt{Alias: alias, Path: path}, nil
@@ -527,7 +539,7 @@ func (p *Parser) parseExternStmt() (*ast.ExternStmt, error) {
 	}
 
 	extType := p.curToken.Text
-	if err := p.expect(lexer.TLiteral); err != nil {
+	if err := p.expectString(); err != nil {
 		return nil, err
 	}
 
@@ -1096,6 +1108,105 @@ func (p *Parser) parseNotExpr() (ast.Expr, error) {
 	}, nil
 }
 
+func (p *Parser) parseStrExpr() (ast.Expr, error) {
+	pos := p.curToken.Pos
+	if err := p.readToken(); err != nil {
+		return nil, err
+	}
+	if err := p.expect(lexer.TLParen); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr(PLowest)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.expect(lexer.TRParen); err != nil {
+		return nil, err
+	}
+	return &ast.StrExpr{
+		Position: ast.Position{Start: &pos, End: &p.curToken.Pos},
+		Value:    expr,
+	}, nil
+}
+
+func (p *Parser) parseInterpolatedStringLiteralExpr() (ast.Expr, error) {
+	pos := p.curToken.Pos
+	text := p.curToken.Text
+	if err := p.readToken(); err != nil {
+		return nil, err
+	}
+
+	texts := []string{}
+	values := []ast.Expr{}
+
+	runes := []rune(text)
+	last := 0
+	var currentText strings.Builder
+
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '{' {
+			if i+1 < len(runes) && runes[i+1] == '{' {
+				currentText.WriteString(string(runes[last:i]))
+				currentText.WriteRune('{')
+				i++
+				last = i + 1
+				continue
+			}
+			// Start of interpolation
+			currentText.WriteString(string(runes[last:i]))
+			texts = append(texts, currentText.String())
+			currentText.Reset()
+
+			i++
+			start := i
+			braceCount := 1
+			for i < len(runes) && braceCount > 0 {
+				switch runes[i] {
+				case '{':
+					braceCount++
+				case '}':
+					braceCount--
+				}
+				if braceCount > 0 {
+					i++
+				}
+			}
+			if braceCount > 0 {
+				return nil, fmt.Errorf("missing closing brace in interpolated string")
+			}
+			exprText := string(runes[start:i])
+
+			subParser := New([]rune(exprText))
+			subParser.readToken()
+			subParser.readToken()
+			subExpr, err := subParser.parseExpr(PLowest)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, subExpr)
+			last = i + 1
+		} else if runes[i] == '}' {
+			if i+1 < len(runes) && runes[i+1] == '}' {
+				currentText.WriteString(string(runes[last:i]))
+				currentText.WriteRune('}')
+				i++
+				last = i + 1
+				continue
+			}
+			// Lone } is just a character if not closing an interpolation
+			// (but our loop only sees this if it's NOT inside one)
+		}
+	}
+	currentText.WriteString(string(runes[last:]))
+	texts = append(texts, currentText.String())
+
+	return &ast.InterpolatedStringLiteralExpr{
+		Position: ast.Position{Start: &pos, End: &p.curToken.Pos},
+		Texts:    texts,
+		Values:   values,
+	}, nil
+}
+
 func (p *Parser) parseDigitLiteralExpr() (ast.Expr, error) {
 	value, err := strconv.ParseFloat(p.curToken.Text, 64)
 	if err != nil {
@@ -1242,7 +1353,7 @@ func (p *Parser) parseTestStmt() (*ast.TestStmt, error) {
 		return nil, err
 	}
 	name := p.curToken.Text
-	if err := p.expect(lexer.TLiteral); err != nil {
+	if err := p.expectString(); err != nil {
 		return nil, err
 	}
 	body, err := p.parseBody()


### PR DESCRIPTION
## Description
This PR implements string interpolation and a new `str` syntax in `vvlang`.

## Changes
- Lexer: Added `TStr` and `TInterpolated` tokens.
- AST: Added `StrExpr` node; reused `InterpolatedStringLiteralExpr`.
- Parser: Added parsing logic for `str()` and interpolated strings (handling `{}`).
- Interpreter: Added `Str()` method to the `Value` interface for raw string content. Implemented evaluation for interpolation and `str()`.
- Escaped Braces: Supported `{{` and `}}` as escaped literal braces.
- Compatibility: Permitted both `TLiteral` and `TInterpolated` in `import`, `extern`, and `test` statements.

## Verification
- Added `interp/interpolation_test.go` and `interp/str_test.go`.
- Verified with the example from Issue #40.
- All tests passed: `go test ./...`.

Closes #40