### PR TITLE
feat: implement `vv doc` command for HTML documentation generation

### DIFF
--- a/cmd/doc-templates/index.html
+++ b/cmd/doc-templates/index.html
@@ -1,0 +1,41 @@
+{{define "title"}}Index{{end}}
+
+{{define "content"}}
+<h1>Modules</h1>
+{{range .Categories}}
+<div class='category'>
+    <h2>{{.Name}}</h2>
+    <ul>
+        {{range .Modules}}
+        <li>
+            <a href='{{.Path}}/index.html'>{{.Name}}</a>
+            {{if .Summary}} — <span class='summary'>{{.Summary}}</span>{{end}}
+        </li>
+        {{end}}
+    </ul>
+</div>
+{{end}}
+<style>
+    .category h2 {
+        background: #eee;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        font-size: 1.2rem;
+    }
+
+    .summary {
+        color: #666;
+        font-style: italic;
+        font-size: 0.9rem;
+    }
+
+    ul {
+        list-style: none;
+        padding-left: 1rem;
+    }
+
+    li {
+        margin-bottom: 0.5rem;
+    }
+</style>
+{{end}}

--- a/cmd/doc-templates/layout.html
+++ b/cmd/doc-templates/layout.html
@@ -1,0 +1,123 @@
+{{define "layout"}}
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <title>{{template "title" .}} - vvlang documentation</title>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            background: #f9f9f9;
+        }
+
+        header {
+            background: #1a1a1a;
+            color: white;
+            padding: 1rem 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        header .logo {
+            font-weight: bold;
+            font-size: 1.2rem;
+        }
+
+        nav.langs a {
+            color: #ccc;
+            text-decoration: none;
+            margin-left: 1rem;
+            font-size: 0.9rem;
+        }
+
+        nav.langs a.active {
+            color: #fff;
+            font-weight: bold;
+            text-decoration: underline;
+        }
+
+        main {
+            max-width: 800px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+        }
+
+        h1 {
+            color: #111;
+            border-bottom: 2px solid #eee;
+            padding-bottom: 0.5rem;
+        }
+
+        h2 {
+            color: #444;
+            margin-top: 2rem;
+        }
+
+        .docstring {
+            background: #fff;
+            padding: 1rem;
+            border-radius: 4px;
+            border-left: 4px solid #007acc;
+            margin: 1rem 0;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+
+        .module-doc {
+            font-size: 1.1rem;
+        }
+
+        .export-item {
+            margin-bottom: 2rem;
+        }
+
+        h3 {
+            margin-bottom: 0.5rem;
+        }
+
+        .kind {
+            font-weight: normal;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            color: #666;
+            background: #eee;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            margin-right: 0.5rem;
+            vertical-align: middle;
+        }
+
+        pre {
+            background: #2d2d2d;
+            color: #f8f8f2;
+            padding: 1rem;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+
+        code {
+            font-family: 'Fira Code', monospace;
+        }
+    </style>
+</head>
+
+<body>
+    <header>
+        <div class='logo'>vvlang docs</div>
+        <nav class='langs'>
+            {{range .AllLangs}}
+            <a href='{{$.RootRel}}{{.}}/index.html' {{if eq . $.CurrentLang}}class='active' {{end}}>{{.}}</a>
+            {{end}}
+        </nav>
+    </header>
+    <main>
+        {{template "content" .}}
+    </main>
+</body>
+
+</html>
+{{end}}

--- a/cmd/doc-templates/module.html
+++ b/cmd/doc-templates/module.html
@@ -1,0 +1,19 @@
+{{define "title"}}{{ .ModName }}{{end}}
+
+{{define "content"}}
+<h1>Module <code>{{ .ModName }}</code></h1>
+
+{{if .Docstring}}
+<div class='docstring module-doc'>{{.Docstring}}</div>
+{{end}}
+
+<h2>Exports</h2>
+{{range .Exports}}
+<div class='export-item'>
+    <h3 id='{{.Name}}'><span class='kind'>{{.Kind}}</span> <code>{{.Name}}{{.Arguments}}</code></h3>
+    {{if .Doc}}
+    <div class='docstring'>{{.Doc}}</div>
+    {{end}}
+</div>
+{{end}}
+{{end}}

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,310 @@
+package cmd
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/fj68/vvlang/ast"
+	"github.com/fj68/vvlang/parser"
+)
+
+//go:embed doc-templates/*.html
+var templatesFS embed.FS
+
+var (
+	moduleTemplate *template.Template
+	indexTemplate  *template.Template
+)
+
+func init() {
+	layout := template.Must(template.ParseFS(templatesFS, "doc-templates/layout.html"))
+
+	moduleTemplate = template.Must(layout.Clone())
+	template.Must(moduleTemplate.ParseFS(templatesFS, "doc-templates/module.html"))
+
+	indexTemplate = template.Must(layout.Clone())
+	template.Must(indexTemplate.ParseFS(templatesFS, "doc-templates/index.html"))
+}
+
+func Doc() {
+	target := "."
+	outputDir := "docs"
+
+	for i := 2; i < len(os.Args); i++ {
+		arg := os.Args[i]
+		if arg == "--output" || arg == "-o" {
+			if i+1 < len(os.Args) {
+				outputDir = os.Args[i+1]
+				i++
+			} else {
+				fmt.Println("error: --output/-o requires an argument")
+				os.Exit(1)
+			}
+		} else if strings.HasPrefix(arg, "-") {
+			fmt.Printf("error: unknown option %s\n", arg)
+			os.Exit(1)
+		} else {
+			target = arg
+		}
+	}
+
+	files, err := collectVVFiles(target)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(files) == 0 {
+		fmt.Println("no .vv files found")
+		return
+	}
+
+	modules := make(map[string]*ast.Module)
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Printf("warning: could not read %s: %v\n", file, err)
+			continue
+		}
+
+		mod, err := parser.Parse([]rune(string(content)))
+		if err != nil {
+			fmt.Printf("warning: could not parse %s: %v\n", file, err)
+			continue
+		}
+		modules[file] = mod
+	}
+
+	if err := generateDocs(modules, outputDir); err != nil {
+		fmt.Printf("error generating docs: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Documentation generated in %s\n", outputDir)
+}
+
+func collectVVFiles(target string) ([]string, error) {
+	info, err := os.Stat(target)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	if info.IsDir() {
+		err := filepath.Walk(target, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				name := info.Name()
+				if name == ".vv-modules" || name == "vendor" || name == ".git" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if filepath.Ext(path) == ".vv" {
+				files = append(files, path)
+			}
+			return nil
+		})
+		return files, err
+	}
+
+	if filepath.Ext(target) == ".vv" {
+		return []string{target}, nil
+	}
+	return nil, fmt.Errorf("%s is not a .vv file", target)
+}
+
+type exportData struct {
+	Kind      string
+	Name      string
+	Arguments string
+	Doc       template.HTML
+}
+
+type modulePageData struct {
+	ModName     string
+	Docstring   template.HTML
+	Exports     []exportData
+	AllLangs    []string
+	CurrentLang string
+	RootRel     string
+}
+
+type indexPageData struct {
+	Categories  []categoryData
+	AllLangs    []string
+	CurrentLang string
+	RootRel     string
+}
+
+type categoryData struct {
+	Name    string
+	Modules []moduleMeta
+}
+
+type moduleMeta struct {
+	Name    string
+	Path    string
+	Summary string
+}
+
+func generateDocs(modules map[string]*ast.Module, outputDir string) error {
+	langs := make(map[string]bool)
+	langs["en"] = true
+
+	for _, mod := range modules {
+		if mod.Docstring != nil {
+			for lang := range mod.Docstring {
+				langs[lang] = true
+			}
+		}
+		for _, stmt := range mod.Statements {
+			if decl, ok := stmt.(*ast.VarDeclStmt); ok {
+				if decl.Docstring != nil {
+					for lang := range decl.Docstring {
+						langs[lang] = true
+					}
+				}
+			}
+		}
+	}
+
+	sortedLangs := []string{}
+	for lang := range langs {
+		sortedLangs = append(sortedLangs, lang)
+	}
+
+	for lang := range langs {
+		langDir := filepath.Join(outputDir, lang)
+		if err := os.MkdirAll(langDir, 0755); err != nil {
+			return fmt.Errorf("mkdir %s: %v", langDir, err)
+		}
+
+		for path, mod := range modules {
+			relPath, _ := filepath.Rel(".", path)
+			modPath := strings.TrimSuffix(relPath, ".vv")
+			modPath = filepath.ToSlash(modPath)
+
+			modDir := filepath.Join(langDir, filepath.FromSlash(modPath))
+			if err := os.MkdirAll(modDir, 0755); err != nil {
+				return err
+			}
+
+			depth := strings.Count(modPath, "/") + 2
+			rootRel := strings.Repeat("../", depth)
+
+			data := modulePageData{
+				ModName:     modPath,
+				Docstring:   template.HTML(formatDoc(getDocstring(mod.Docstring, lang))),
+				AllLangs:    sortedLangs,
+				CurrentLang: lang,
+				RootRel:     rootRel,
+			}
+
+			for name, stmt := range mod.Exports {
+				exp := exportData{Name: name}
+				switch s := stmt.(type) {
+				case *ast.VarDeclStmt:
+					exp.Kind = "variable"
+					if fun, ok := s.Body.(*ast.FunLiteralExpr); ok {
+						exp.Kind = "function"
+						exp.Arguments = "(" + strings.Join(fun.Args, ", ") + ")"
+					}
+					exp.Doc = template.HTML(formatDoc(getDocstring(s.Docstring, lang)))
+				case *ast.ExternStmt:
+					exp.Kind = "extern"
+				}
+				data.Exports = append(data.Exports, exp)
+			}
+
+			f, err := os.Create(filepath.Join(modDir, "index.html"))
+			if err != nil {
+				return err
+			}
+			if err := moduleTemplate.ExecuteTemplate(f, "layout", data); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+
+		indexData := indexPageData{
+			AllLangs:    sortedLangs,
+			CurrentLang: lang,
+			RootRel:     "../",
+		}
+
+		// Group modules by directory
+		catMap := make(map[string][]moduleMeta)
+		for path, mod := range modules {
+			relPath, _ := filepath.Rel(".", path)
+			modPath := strings.TrimSuffix(relPath, ".vv")
+			modPath = filepath.ToSlash(modPath)
+
+			cat := "."
+			if idx := strings.LastIndex(modPath, "/"); idx != -1 {
+				cat = modPath[:idx]
+			}
+
+			summary := ""
+			modDoc := getDocstring(mod.Docstring, lang)
+			if modDoc != "" {
+				lines := strings.Split(modDoc, "\n")
+				if len(lines) > 0 {
+					summary = lines[0]
+				}
+			}
+
+			catMap[cat] = append(catMap[cat], moduleMeta{
+				Name:    modPath,
+				Path:    modPath,
+				Summary: summary,
+			})
+		}
+
+		// Convert map to sorted slice
+		for catName, mods := range catMap {
+			sort.Slice(mods, func(i, j int) bool {
+				return mods[i].Name < mods[j].Name
+			})
+			indexData.Categories = append(indexData.Categories, categoryData{
+				Name:    catName,
+				Modules: mods,
+			})
+		}
+		sort.Slice(indexData.Categories, func(i, j int) bool {
+			return indexData.Categories[i].Name < indexData.Categories[j].Name
+		})
+
+		f, err := os.Create(filepath.Join(langDir, "index.html"))
+		if err != nil {
+			return err
+		}
+		if err := indexTemplate.ExecuteTemplate(f, "layout", indexData); err != nil {
+			f.Close()
+			return err
+		}
+		f.Close()
+	}
+
+	return nil
+}
+
+func getDocstring(docs map[string]string, lang string) string {
+	if val, ok := docs[lang]; ok && val != "" {
+		return val
+	}
+	return docs["en"]
+}
+
+func formatDoc(doc string) string {
+	lines := strings.Split(doc, "\n")
+	return strings.Join(lines, "<br>\n")
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func main() {
 		cmd.Clean()
 	case "test":
 		cmd.Test()
+	case "doc":
+		cmd.Doc()
 	default:
 		cmd.Run()
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -188,7 +188,7 @@ func (p *Parser) parseDocstring() map[string]string {
 	for p.curToken.Type == lexer.TDocstring {
 		line := p.curToken.Text
 		if len(line) >= 6 && line[:6] == "@lang " {
-			lang = line[6:]
+			lang = strings.TrimSpace(line[6:])
 			// Consume the @lang token and move on
 			if err := p.readToken(); err != nil {
 				break


### PR DESCRIPTION
This PR implements the `vv doc` command, which generates HTML documentation from docstrings in `.vv` files.

## Features

 - Multi-language support with fallback to English
 - Categorized module list in Table of Contents
 - Module summaries extracted from docstrings
 - Customizability using html/template and go:embed

Closes #62