### PR TITLE
feat: add property shorthand for record destructuring (#67)

### DIFF
--- a/parser/parser_expr.go
+++ b/parser/parser_expr.go
@@ -520,17 +520,28 @@ func (p *Parser) parseRecordLiteralExpr() (ast.Expr, error) {
 			return nil, fmt.Errorf("expected identifier for record field, got %s", p.curToken.Type)
 		}
 		name := p.curToken.Text
-		if err := p.expectNext(lexer.TAssign); err != nil {
-			return nil, err
+
+		if p.peekToken.Type == lexer.TComma || p.peekToken.Type == lexer.TRBracket {
+			fields[name] = &ast.VarRefExpr{
+				Name: name,
+			}
+			if err := p.readToken(); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := p.expectNext(lexer.TAssign); err != nil {
+				return nil, err
+			}
+			if err := p.readToken(); err != nil {
+				return nil, err
+			}
+			expr, err := p.parseExpr(PLowest)
+			if err != nil {
+				return nil, err
+			}
+			fields[name] = expr
 		}
-		if err := p.readToken(); err != nil {
-			return nil, err
-		}
-		expr, err := p.parseExpr(PLowest)
-		if err != nil {
-			return nil, err
-		}
-		fields[name] = expr
+
 		if p.curToken.Type == lexer.TRBracket {
 			break
 		}

--- a/parser/parser_expr_test.go
+++ b/parser/parser_expr_test.go
@@ -62,6 +62,35 @@ func TestParseExpr(t *testing.T) {
 			},
 		},
 		{
+			Name:  "record property shorthand",
+			Input: "let r = { name, age }",
+			Expected: []ast.Stmt{
+				&ast.VarDeclStmt{
+					Name: "r",
+					Body: &ast.RecordLiteralExpr{
+						Fields: map[string]ast.Expr{
+							"name": &ast.VarRefExpr{Name: "name"},
+							"age":  &ast.VarRefExpr{Name: "age"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "record property shorthand trailing comma",
+			Input: "let r = { name, }",
+			Expected: []ast.Stmt{
+				&ast.VarDeclStmt{
+					Name: "r",
+					Body: &ast.RecordLiteralExpr{
+						Fields: map[string]ast.Expr{
+							"name": &ast.VarRefExpr{Name: "name"},
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:  "len(xs)",
 			Input: "let x = len(xs)",
 			Expected: []ast.Stmt{


### PR DESCRIPTION
Implementation of property shorthand for record destructuring which allows omitting the value when it matches the key name. This is consistent with other modern languages that support record/object destructuring.